### PR TITLE
Use zeitwerk if possible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.0.2)
+    eventboss (1.0.3)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       concurrent-ruby (~> 1.0, >= 1.0.5)
@@ -11,17 +11,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.0.3)
-    aws-partitions (1.161.0)
-    aws-sdk-core (3.51.0)
+    aws-partitions (1.167.0)
+    aws-sdk-core (3.53.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-sns (1.13.0)
-      aws-sdk-core (~> 3, >= 3.48.2)
+    aws-sdk-sns (1.16.0)
+      aws-sdk-core (~> 3, >= 3.53.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.13.0)
-      aws-sdk-core (~> 3, >= 3.48.2)
+    aws-sdk-sqs (1.16.0)
+      aws-sdk-core (~> 3, >= 3.53.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
@@ -54,4 +54,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/bin/eventboss
+++ b/bin/eventboss
@@ -27,7 +27,15 @@ begin
     require File.expand_path('config/application.rb')
     require File.expand_path('config/environment.rb')
   end
-  ::Rails.application.eager_load!
+
+  # Due to a changes introduced in Rails 6 regarding autoloading
+  # we need to determine how to perform eager_load
+  # @see https://weblog.rubyonrails.org/2019/2/22/zeitwerk-integration-in-rails-6-beta-2/
+  if ::Rails.try(:autoloaders).try(:zeitwerk_enabled?)
+    ::Zeitwerk::Loader.eager_load_all
+  else
+    ::Rails.application.eager_load!
+  end
 rescue LoadError
   logger.debug('Seems like not a Rails app')
 

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
Due to a changes introduced in Rails 6 regarding autoloading we need to determine how to perform eager_load. Please check https://weblog.rubyonrails.org/2019/2/22/zeitwerk-integration-in-rails-6-beta-2/ for more details.