### PR TITLE
Expose raise_on_missing_configuration in ENV

### DIFF
--- a/lib/eventboss/configuration.rb
+++ b/lib/eventboss/configuration.rb
@@ -17,7 +17,7 @@ module Eventboss
                 :sns_sqs_name_infix
 
     def raise_on_missing_configuration
-      defined_or_default('raise_on_missing_configuration') { false }
+      defined_or_default('raise_on_missing_configuration') { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION']&.downcase == 'true' }
     end
 
     def error_handlers

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end

--- a/spec/eventboss/configuration_spec.rb
+++ b/spec/eventboss/configuration_spec.rb
@@ -16,6 +16,26 @@ RSpec.describe Eventboss::Configuration do
     it 'caches evaluated default' do
       expect(subject.sns_client.object_id).to eq(subject.sns_client.object_id)
     end
+
+    context 'when in ENV' do
+      after { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = nil }
+
+      context 'when false' do
+        before { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = 'false' }
+
+        it 'returns false' do
+          expect(subject.raise_on_missing_configuration).to eq(false)
+        end
+      end
+
+      context 'when true' do
+        before { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = 'true' }
+
+        it 'returns true' do
+          expect(subject.raise_on_missing_configuration).to eq(true)
+        end
+      end
+    end
   end
 
   describe '#concurrency' do

--- a/spec/eventboss/configuration_spec.rb
+++ b/spec/eventboss/configuration_spec.rb
@@ -21,18 +21,22 @@ RSpec.describe Eventboss::Configuration do
       after { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = nil }
 
       context 'when false' do
-        before { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = 'false' }
+        %w(false False FALSE not_know).each do |falsey_value|
+          before { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = falsey_value }
 
-        it 'returns false' do
-          expect(subject.raise_on_missing_configuration).to eq(false)
+          it "returns false for #{falsey_value}" do
+            expect(subject.raise_on_missing_configuration).to eq(false)
+          end
         end
       end
 
       context 'when true' do
-        before { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = 'true' }
+        %w(true TRUE True).each do |truthy_value|
+          before { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = 'true' }
 
-        it 'returns true' do
-          expect(subject.raise_on_missing_configuration).to eq(true)
+          it "returns true for #{truthy_value}" do
+            expect(subject.raise_on_missing_configuration).to eq(true)
+          end
         end
       end
     end


### PR DESCRIPTION
SInce eventboss might have a different configuration on different environments we do want to have the ability to skip rising the exception on missing configuration directly from ENV variable (not only from the initializer which is the same for all the environments).

Introducting `EVENTBUS_RAISE_ON_MISSING_CONFIGURATION` ENV flag for it.