### PR TITLE
Fix: reload rake task - removed additional suffix "-"

### DIFF
--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.0.5"
+  VERSION = "1.0.6"
 end

--- a/lib/tasks/eventboss.rake
+++ b/lib/tasks/eventboss.rake
@@ -4,7 +4,7 @@ namespace :eventboss do
   namespace :deadletter do
     desc 'Reload deadletter queue'
     task :reload, [:event_name, :source_app, :max_messages] do |_, args|
-      source_app = args[:source_app] ? "#{args[:source_app]}-" : ''
+      source_app = args[:source_app]
       event_name = args[:event_name]
 
       # Zero means, fetch all messages


### PR DESCRIPTION
We don't need this suffix "-" in source_app when we combine queue_name with .join("-")