### PR TITLE
Load environment in reload task

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ AWS_SNS_ENDPOINT=http://localhost:4575 # when using with localstack
 AWS_SQS_ENDPOINT=http://localhost:4576 # when using with localstack
 ```
 
+Be aware that `eventbus:deadletter:reload` rake task won't load your configuration if you are not using ENVs
+ in non Rails app, although to make it work you can extend your `Rakefile` with:
+
+```ruby
+load File.join(Gem::Specification.find_by_name('eventboss').gem_dir, 'lib', 'tasks', 'eventboss.rake')
+
+task :environment do
+  # Load your environment
+  # Example:
+  # require_relative 'config/application'
+end
+
+task 'eventboss:deadletter:reload': :environment
+```
+
 ### Logging and error handling
 To have more verbose logging, set `log_level` in configuration (default is `info`).
 

--- a/lib/eventboss/railtie.rb
+++ b/lib/eventboss/railtie.rb
@@ -1,5 +1,9 @@
 class Eventboss::Railtie < Rails::Railtie
   rake_tasks do
     load 'tasks/eventboss.rake'
+
+    # Load rails environment before executing reload.
+    # It makes sure to load configuration file.
+    task 'eventboss:deadletter:reload': :environment
   end
 end

--- a/lib/tasks/eventboss.rake
+++ b/lib/tasks/eventboss.rake
@@ -21,7 +21,7 @@ namespace :eventboss do
         source_app,
         event_name,
         Eventboss.env
-      ].join('-')
+      ].compact.join('-')
       puts "[#{task.name}] Reloading #{queue_name}-deadletter (max: #{ max_messages }, batch: #{ batch_size })"
       queue = Eventboss::Queue.new("#{queue_name}-deadletter")
       send_queue = Eventboss::Queue.new(queue_name)

--- a/spec/eventboss/configuration_spec.rb
+++ b/spec/eventboss/configuration_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Eventboss::Configuration do
 
       context 'when true' do
         %w(true TRUE True).each do |truthy_value|
-          before { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = 'true' }
+          before { ENV['EVENTBUS_RAISE_ON_MISSING_CONFIGURATION'] = truthy_value }
 
           it "returns true for #{truthy_value}" do
             expect(subject.raise_on_missing_configuration).to eq(true)


### PR DESCRIPTION
I've been trying to run `eventboss:deadletter:reload` rake and ended up with `The specified queue does not exist for this wsdl version`. After some investigation I figured out that my initializer is not loaded before running rake. With missing configuration queue name was wrongly build. 

- Added `compact` before joining in queue_name generation 
In case of generic queue (without source_app) queue_name would end up with two dashes in a row
- Added environment loading to reload task if `Rails` is defined + description how to handle it in non Rails app (while using config files)
- Improved one of configuration specs to properly use value from each loop