### PR TITLE
Drop dependency on concurrent-ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,15 +4,14 @@ PATH
     eventboss (1.1.1)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
-      concurrent-ruby (~> 1.0, >= 1.0.5)
       dotenv (~> 2.1, >= 2.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.0.3)
-    aws-partitions (1.206.0)
-    aws-sdk-core (3.64.0)
+    aws-partitions (1.210.0)
+    aws-sdk-core (3.66.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.1)
@@ -20,12 +19,11 @@ GEM
     aws-sdk-sns (1.19.0)
       aws-sdk-core (~> 3, >= 3.61.1)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.21.0)
+    aws-sdk-sqs (1.22.0)
       aws-sdk-core (~> 3, >= 3.61.1)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
-    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
     dotenv (2.7.5)
     jmespath (1.4.0)

--- a/eventboss.gemspec
+++ b/eventboss.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = ["eventboss"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "concurrent-ruby", "~> 1.0", ">= 1.0.5"
   spec.add_dependency "aws-sdk-sqs", ">= 1.3.0"
   spec.add_dependency "aws-sdk-sns", ">= 1.1.0"
   spec.add_dependency "dotenv", "~> 2.1", ">= 2.1.1"

--- a/lib/eventboss.rb
+++ b/lib/eventboss.rb
@@ -1,6 +1,5 @@
 require 'aws-sdk-sqs'
 require 'aws-sdk-sns'
-require 'concurrent'
 require 'securerandom'
 
 require 'eventboss/version'

--- a/lib/eventboss/launcher.rb
+++ b/lib/eventboss/launcher.rb
@@ -66,7 +66,7 @@ module Eventboss
     private
 
     def worker_count
-      @options.fetch(:worker_count, [2, Concurrent.processor_count].max)
+      @options.fetch(:worker_count, 2)
     end
 
     def new_worker(id)


### PR DESCRIPTION
Eventboss manages its own threads pool/state, no need to include it.

Only drawback was to know minimum number of workers, however this variable is configured by `concurrency` setting anyway.