### PR TITLE
Fixed config setter for concurrency

### DIFF
--- a/lib/eventboss/configuration.rb
+++ b/lib/eventboss/configuration.rb
@@ -32,6 +32,10 @@ module Eventboss
       defined_or_default('concurrency') { ENV['EVENTBUS_CONCURRENCY'] ? ENV['EVENTBUS_CONCURRENCY'].to_i : 25 }
     end
 
+    def concurrency=(value)
+      defined_or_default('concurrency') { Integer(value) }
+    end
+
     def log_level
       defined_or_default('log_level') { :info }
     end

--- a/spec/eventboss/configuration_spec.rb
+++ b/spec/eventboss/configuration_spec.rb
@@ -57,5 +57,29 @@ RSpec.describe Eventboss::Configuration do
         expect(subject).to eq(10)
       end
     end
+
+    context 'when set through configuration' do
+      context 'when set a correct string value' do
+        before { configuration.concurrency = '11' }
+
+        it 'returns int value' do
+          expect(subject).to eq(11)
+        end
+      end
+
+      context 'when set an incorrect string value' do
+        subject { configuration.concurrency = 'incorrect value' }
+
+        it 'raises an error' do
+          expect { subject }.to raise_error(ArgumentError)
+        end
+      end
+
+      context 'when set an int value' do
+        before { configuration.concurrency = 11 }
+
+        it { expect(subject).to eq(11) }
+      end
+    end
   end
 end


### PR DESCRIPTION
This prevents from string to int cast issues for `concurrency` setter