### PR TITLE
Add development mode

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.3.1)
+    eventboss (1.3.2)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)
@@ -10,16 +10,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.0.3)
-    aws-partitions (1.232.0)
-    aws-sdk-core (3.73.0)
+    aws-partitions (1.269.0)
+    aws-sdk-core (3.89.1)
       aws-eventstream (~> 1.0, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.228.0)
+      aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-sns (1.20.0)
+    aws-sdk-sns (1.21.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.23.0)
+    aws-sdk-sqs (1.23.1)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)

--- a/lib/eventboss/configuration.rb
+++ b/lib/eventboss/configuration.rb
@@ -1,27 +1,29 @@
+# frozen_string_literal: true
+
 module Eventboss
   class Configuration
     OPTS_ALLOWED_IN_CONFIG_FILE = %i[
       concurrency
       sns_sqs_name_infix
       listeners
-    ]
+    ].freeze
 
     attr_writer :raise_on_missing_configuration,
-                :error_handlers,
-                :concurrency,
-                :log_level,
-                :logger,
-                :sns_client,
-                :sqs_client,
-                :eventboss_region,
-                :eventboss_app_name,
-                :eventboss_account_id,
-                :aws_access_key_id,
-                :aws_secret_access_key,
-                :aws_sns_endpoint,
-                :aws_sqs_endpoint,
-                :sns_sqs_name_infix,
-                :listeners
+      :error_handlers,
+      :concurrency,
+      :log_level,
+      :logger,
+      :sns_client,
+      :sqs_client,
+      :eventboss_region,
+      :eventboss_app_name,
+      :eventboss_account_id,
+      :aws_access_key_id,
+      :aws_secret_access_key,
+      :aws_sns_endpoint,
+      :aws_sqs_endpoint,
+      :sns_sqs_name_infix,
+      :listeners
 
 
     def raise_on_missing_configuration
@@ -108,6 +110,12 @@ module Eventboss
 
     def listeners
       defined_or_default('listeners') { {} }
+    end
+
+    def development_mode?
+      defined_or_default('development_mode') do
+        (ENV['EVENTBOSS_DEVELOPMENT_MODE']&.downcase || ENV['EVENTBUS_DEVELOPMENT_MODE'])&.downcase == 'true'
+      end
     end
 
     private

--- a/lib/eventboss/development_mode.rb
+++ b/lib/eventboss/development_mode.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Eventboss
+  module DevelopmentMode
+    extend Logging
+
+    class << self
+      def setup_infrastructure(queues)
+        sns_client = Eventboss.configuration.sns_client
+        sqs_client = Eventboss.configuration.sqs_client
+
+        queues.each do |queue, listener|
+          topic_name = Eventboss::Topic.build_name(**listener.options)
+          logger.info('development-mode') { "Creating topic #{topic_name}..." }
+          topic = sns_client.create_topic(name: topic_name)
+
+          logger.info('development-mode') { "Creating queue #{queue.name}..." }
+          sqs_client.create_queue(queue_name: queue.name)
+
+          logger.info('development-mode') { "Setting up queue #{queue.name} policy..." }
+          policy = queue_policy(queue.arn, topic.topic_arn)
+          sqs_client.set_queue_attributes(queue_url: queue.url, attributes: { Policy: policy.to_json })
+
+          logger.info('development-mode') { "Creating subscription for topic #{topic.topic_arn} and #{queue.arn}..." }
+          sns_client.create_subscription(topic_arn: topic.topic_arn, queue_arn: queue.arn)
+        end
+      end
+
+      def queue_policy(queue_arn, topic_arn)
+        {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Sid": "queue-policy-#{queue_arn}-#{topic_arn}",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": ["SQS:SendMessage"],
+            "Resource": "#{queue_arn}",
+            "Condition": {
+              "ArnEquals": {
+                "aws:SourceArn": "#{topic_arn}"
+              }
+            }
+          }]
+        }
+      end
+    end
+  end
+end

--- a/lib/eventboss/error_handlers/logger.rb
+++ b/lib/eventboss/error_handlers/logger.rb
@@ -6,7 +6,7 @@ module Eventboss
         notice[:jid] = notice[:processor].jid if notice[:processor]
         notice[:processor] = notice[:processor].class.to_s if notice[:processor]
         Eventboss.logger.error(notice) do
-          "Failure processing request #{exception.message}"
+          "Failure processing request: #{exception.message}"
         end
       end
     end

--- a/lib/eventboss/listener.rb
+++ b/lib/eventboss/listener.rb
@@ -17,15 +17,12 @@ module Eventboss
     end
 
     module ClassMethods
-      def eventboss_options(opts)
-        source_app = opts[:source_app] ? "#{opts[:source_app]}-" : ""
-        event_name = opts[:event_name]
-        destination_app = opts[:destination_app]
+      attr_reader :options
 
-        ACTIVE_LISTENERS["#{source_app}#{event_name}"] = {
-          listener: self,
-          destination_app: destination_app
-        }
+      def eventboss_options(options)
+        @options = options.compact
+
+        ACTIVE_LISTENERS[@options] = self
       end
     end
   end

--- a/lib/eventboss/publisher.rb
+++ b/lib/eventboss/publisher.rb
@@ -1,32 +1,28 @@
+# frozen_string_literal: true
+
 module Eventboss
   class Publisher
     def initialize(event_name, sns_client, configuration, opts = {})
       @event_name = event_name
       @sns_client = sns_client
       @configuration = configuration
-      @generic = opts[:generic]
+      @source = configuration.eventboss_app_name unless opts[:generic]
     end
 
     def publish(payload)
-      sns_client.publish({
+      topic_arn = Topic.build_arn(event_name: event_name, source_app: source)
+      sns_client.publish(
         topic_arn: topic_arn,
         message: json_payload(payload)
-      })
+      )
     end
 
     private
 
-    attr_reader :event_name, :sns_client, :configuration
+    attr_reader :event_name, :sns_client, :configuration, :source
 
     def json_payload(payload)
       payload.is_a?(String) ? payload : payload.to_json
-    end
-
-    def topic_arn
-      src_selector = @generic ? "" : "-#{configuration.eventboss_app_name}"
-
-      "arn:aws:sns:#{configuration.eventboss_region}:#{configuration.eventboss_account_id}:\
-#{Eventboss.configuration.sns_sqs_name_infix}#{src_selector}-#{event_name}-#{Eventboss.env}"
     end
   end
 end

--- a/lib/eventboss/queue.rb
+++ b/lib/eventboss/queue.rb
@@ -1,26 +1,48 @@
+# frozen_string_literal: true
+
 module Eventboss
   class Queue
     include Comparable
     attr_reader :name
 
-    def self.build_name(source:, destination:, event:, env:, generic:)
-      source =
-        if generic
-          ''
-        else
-          "#{source}-"
-        end
+    class << self
+      def build_name(destination:, event_name:, env:, source_app: nil)
+        [
+          destination,
+          Eventboss.configuration.sns_sqs_name_infix,
+          source_app,
+          event_name,
+          env
+        ].compact.join('-')
+      end
 
-      "#{destination}-#{Eventboss.configuration.sns_sqs_name_infix}-#{source}#{event}-#{env}"
+      def build(destination:, event_name:, env:, source_app: nil)
+        name = build_name(
+          destination: destination,
+          event_name: event_name,
+          env: env,
+          source_app: source_app
+        )
+        Queue.new(name)
+      end
     end
 
-    def initialize(name, configuration = Eventboss.configuration)
-      @client = configuration.sqs_client
+    def initialize(name)
+      @client = Eventboss.configuration.sqs_client
       @name = name
     end
 
     def url
       @url ||= client.get_queue_url(queue_name: name).queue_url
+    end
+
+    def arn
+      [
+        'arn:aws:sqs',
+        Eventboss.configuration.eventboss_region,
+        Eventboss.configuration.eventboss_account_id,
+        name
+      ].join(':')
     end
 
     def <=>(another_queue)
@@ -33,6 +55,10 @@ module Eventboss
 
     def hash
       name.hash
+    end
+
+    def to_s
+      "<Eventboss::Queue: #{name}>"
     end
 
     private

--- a/lib/eventboss/runner.rb
+++ b/lib/eventboss/runner.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Eventboss
   class Runner
     extend Logging
@@ -17,8 +19,11 @@ module Eventboss
 
         self_read = setup_signals([:SIGTERM])
 
-        logger.info('Active Listeners:')
-        logger.info(queues.to_s)
+        logger.info('Active listeners:')
+        queues.each { |queue, listener| logger.info("#{queue}: #{listener}") }
+
+        Eventboss::DevelopmentMode.setup_infrastructure(queues) if config.development_mode?
+
         begin
           launcher.start
           handle_signals(self_read, launcher)
@@ -45,7 +50,7 @@ module Eventboss
       def handle_signals(self_read, launcher)
         while readable_io = IO.select([self_read])
           signal = readable_io.first[0].gets.strip
-          logger.info('runner') { "Received #{ signal } signal, gracefully shutdowning..." }
+          logger.info('runner') { "Received #{signal} signal, gracefully shutting down..." }
 
           launcher.stop
           exit 0

--- a/lib/eventboss/topic.rb
+++ b/lib/eventboss/topic.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Eventboss
+  class Topic
+    class << self
+      def build_arn(event_name:, source_app: nil)
+        [
+          'arn:aws:sns',
+          Eventboss.configuration.eventboss_region,
+          Eventboss.configuration.eventboss_account_id,
+          build_name(
+            event_name: event_name,
+            source_app: source_app
+          )
+        ].join(':')
+      end
+
+      def build_name(event_name:, source_app: nil)
+        [
+          Eventboss.configuration.sns_sqs_name_infix,
+          source_app,
+          event_name,
+          Eventboss.env
+        ].compact.join('-')
+      end
+    end
+  end
+end

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/spec/eventboss/configuration_spec.rb
+++ b/spec/eventboss/configuration_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Eventboss::Configuration do
@@ -56,6 +58,22 @@ RSpec.describe Eventboss::Configuration do
       it 'is taken from ENV' do
         expect(subject).to eq(10)
       end
+    end
+  end
+
+  describe '#development_mode?' do
+    subject { configuration.development_mode? }
+
+    context 'by default' do
+      before { ENV['EVENTBUS_DEVELOPMENT_MODE'] = 'what do you do in the bath' }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'when set via ENV' do
+      before { ENV['EVENTBUS_DEVELOPMENT_MODE'] = 'true' }
+
+      it { is_expected.to be(true) }
     end
   end
 end

--- a/spec/eventboss/development_mode_spec.rb
+++ b/spec/eventboss/development_mode_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Eventboss::DevelopmentMode do
+  describe 'development mode' do
+    let(:queue1) { double(name: 'Q1', arn: 'Q: Q1', url: 'Q1.url') }
+    let(:queue2) { double(name: 'Q2', arn: 'Q: Q2', url: 'Q2.url') }
+    let(:listener1) { double(name: 'L1', options: { app_name: 'A1' }) }
+    let(:listener2) { double(name: 'L2', options: { app_name: 'A2' }) }
+    let(:queues) { { queue1 => listener1, queue2 => listener2 } }
+    let(:topic1) { double(topic_arn: 'T1') }
+    let(:topic2) { double(topic_arn: 'T2') }
+    let(:sns_client) { double }
+    let(:sqs_client) { double }
+
+    before do
+      allow(Eventboss.configuration).to receive(:development_mode?).and_return(true)
+      allow(Eventboss.configuration).to receive(:sqs_client).and_return(sqs_client)
+      allow(Eventboss.configuration).to receive(:sns_client).and_return(sns_client)
+      allow(Eventboss::Topic).to receive(:build_name).with(app_name: 'A1').and_return('T1')
+      allow(Eventboss::Topic).to receive(:build_name).with(app_name: 'A2').and_return('T2')
+      allow(sqs_client).to receive(:create_queue).with(queue_name: 'Q1')
+      allow(sqs_client).to receive(:create_queue).with(queue_name: 'Q2')
+      allow(sns_client).to receive(:create_topic).with(name: 'T1').and_return(topic1)
+      allow(sns_client).to receive(:create_topic).with(name: 'T2').and_return(topic2)
+      allow(sns_client).to receive(:create_subscription)
+        .with(topic_arn: 'T1', queue_arn: 'Q: Q1').and_return(topic1)
+      allow(sns_client).to receive(:create_subscription)
+        .with(topic_arn: 'T2', queue_arn: 'Q: Q2').and_return(topic2)
+      allow(sqs_client).to receive(:set_queue_attributes).with(queue_url: 'Q1.url', attributes: hash_including(:Policy))
+      allow(sqs_client).to receive(:set_queue_attributes).with(queue_url: 'Q2.url', attributes: hash_including(:Policy))
+    end
+
+    it 'creates required topics' do
+      described_class.setup_infrastructure(queues)
+
+      expect(sns_client).to have_received(:create_topic).with(name: 'T1')
+      expect(sns_client).to have_received(:create_topic).with(name: 'T2')
+    end
+
+    it 'creates queues' do
+      described_class.setup_infrastructure(queues)
+
+      expect(sqs_client).to have_received(:create_queue).with(queue_name: 'Q1')
+      expect(sqs_client).to have_received(:create_queue).with(queue_name: 'Q2')
+      expect(sqs_client).to have_received(:set_queue_attributes).with(queue_url: 'Q1.url', attributes: hash_including(:Policy))
+    end
+
+    it 'subscribes topics to queues' do
+      described_class.setup_infrastructure(queues)
+
+      expect(sns_client).to have_received(:create_subscription).with(queue_arn: 'Q: Q1', topic_arn: 'T1')
+      expect(sns_client).to have_received(:create_subscription).with(queue_arn: 'Q: Q2', topic_arn: 'T2')
+    end
+  end
+end

--- a/spec/eventboss/fetcher_spec.rb
+++ b/spec/eventboss/fetcher_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
 describe Eventboss::Fetcher do
-  let(:queue) { Eventboss::Queue.new('test', configuration) }
-  let(:client_mock) { double('client_mock', get_queue_url: double(queue_url: 'url'))}
+  let(:queue) { instance_double(Eventboss::Queue, url: 'url') }
+  let(:client_mock) { double('client_mock', get_queue_url: double(queue_url: 'url')) }
   let(:configuration) do
     Eventboss::Configuration.new.tap do |config|
       config.sqs_client = client_mock
@@ -20,7 +20,7 @@ describe Eventboss::Fetcher do
   context '#fetch' do
     context 'when limit higher that 10' do
       it 'calls receive client with max no msg eq 10' do
-        expect(client_mock).to receive(:receive_message).with(queue_url: queue.url, max_number_of_messages: 10).and_return(double(messages: [1, 2, 3]))
+        expect(client_mock).to receive(:receive_message).with(queue_url: 'url', max_number_of_messages: 10).and_return(double(messages: [1, 2, 3]))
         expect(subject.fetch(queue, 20)).to eq([1, 2, 3])
       end
     end

--- a/spec/eventboss/listener_spec.rb
+++ b/spec/eventboss/listener_spec.rb
@@ -17,6 +17,12 @@ describe Eventboss::Listener do
     end
   end
 
+  context '.options' do
+    it 'allows to access eventboss_options' do
+      expect(Listener1.options).to eq(source_app: "app1", event_name: "transaction_created")
+    end
+  end
+
   context '#jid' do
     it 'creates unique jid for the job' do
       expect(Listener1.new.jid).not_to be_nil
@@ -27,8 +33,8 @@ describe Eventboss::Listener do
   context '#ACTIVE_LISTENERS' do
     it 'adds the class to active listeners hash' do
       expect(Eventboss::Listener::ACTIVE_LISTENERS).to eq(
-        "transaction_created" => { listener: GenericListener1, destination_app: 'dest_app' },
-        "app1-transaction_created" => { listener: Listener1, destination_app: nil }
+        { event_name: "transaction_created", destination_app: 'dest_app' } => GenericListener1,
+        { source_app: "app1", event_name: "transaction_created" } => Listener1
       )
     end
   end

--- a/spec/eventboss/publisher_spec.rb
+++ b/spec/eventboss/publisher_spec.rb
@@ -1,8 +1,18 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Eventboss::Publisher do
+  before do
+    ENV['EVENTBUS_DEVELOPMENT_MODE'] = 'false'
+    allow(Eventboss).to receive(:env).and_return('ping')
+    allow(Eventboss::Topic).to receive(:build_arn).with(event_name: 'event_name', source_app: 'app_name1')
+      .and_return("arn:aws:sns:::eventboss-app_name1-event_name-ping")
+  end
+
   describe '#publish' do
     subject { described_class.new('event_name', sns_client, configuration, opts).publish(payload) }
+
     let(:payload) { '{}' }
     let(:sns_client) { instance_double(Eventboss::SnsClient, publish: sns_response) }
     let(:sns_response) { double }
@@ -15,21 +25,37 @@ RSpec.describe Eventboss::Publisher do
 
     it 'publishes to sns with source app name by default' do
       expect(sns_client).to receive(:publish).with(
-        topic_arn: "arn:aws:sns:::eventboss-app_name1-event_name-#{Eventboss.env}",
+        topic_arn: "arn:aws:sns:::eventboss-app_name1-event_name-ping",
         message: "{}"
       )
       expect(subject).to eq(sns_response)
     end
 
+    it 'uses Topic.build_arn' do
+      subject
+      expect(Eventboss::Topic).to have_received(:build_arn)
+        .with(event_name: 'event_name', source_app: 'app_name1')
+    end
+
     context 'when generic event' do
       let(:opts) { { generic: true } }
 
+      before do
+        allow(Eventboss::Topic).to receive(:build_arn).with(event_name: 'event_name', source_app: nil)
+          .and_return("arn:aws:sns:::eventboss-event_name-ping")
+      end
+
+      it 'builds topic arn without source app name' do
+        subject
+        expect(Eventboss::Topic).to have_received(:build_arn).with(event_name: 'event_name', source_app: nil)
+      end
+
       it 'publishes to sns without app name' do
         expect(sns_client).to receive(:publish).with(
-          topic_arn: "arn:aws:sns:::eventboss-event_name-#{Eventboss.env}",
+          topic_arn: "arn:aws:sns:::eventboss-event_name-ping",
           message: "{}"
         )
-        expect(subject).to eq(sns_response)
+        subject
       end
     end
   end

--- a/spec/eventboss/runner_spec.rb
+++ b/spec/eventboss/runner_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Eventboss::Runner do
@@ -11,13 +13,42 @@ describe Eventboss::Runner do
         config.logger = Logger.new(IO::NULL)
       end
     end
+    let(:queue1) { double(name: 'Q1', arn: 'Q: Q1') }
+    let(:queue2) { double(name: 'Q2', arn: 'Q: Q2') }
+    let(:listener1) { double(name: 'L1', options: {}) }
+    let(:listener2) { double(name: 'L2', options: {}) }
+    let(:queues) { { queue1 => listener1, queue2 => listener2 } }
+    let(:topic) { double(topic_arn: 'T1') }
+    let(:launcher) { instance_double(Eventboss::Launcher) }
+    let(:sns_client) { double }
+    let(:sqs_client) { double }
+
+    before do
+      ENV['EVENTBUS_DEVELOPMENT_MODE'] = 'false'
+      allow(Eventboss.configuration).to receive(:sqs_client).and_return(sqs_client)
+      allow(Eventboss.configuration).to receive(:sns_client).and_return(sns_client)
+      allow(Eventboss::QueueListener).to receive(:select).and_return(queues)
+      allow(Eventboss::Instrumentation).to receive(:add).with(queues)
+      allow(Eventboss::Launcher).to receive(:new).and_return(launcher)
+      allow(Eventboss::Topic).to receive(:build_name).and_return('T')
+      allow(sqs_client).to receive(:create_queue).with(queue_name: 'Q1')
+      allow(sqs_client).to receive(:create_queue).with(queue_name: 'Q2')
+      allow(sns_client).to receive(:create_topic).with(name: 'T').and_return(topic)
+      allow(sns_client).to receive(:create_subscription)
+        .with(topic_arn: 'T1', queue_arn: 'Q: Q1').and_return(topic)
+      allow(sns_client).to receive(:create_subscription)
+        .with(topic_arn: 'T1', queue_arn: 'Q: Q2').and_return(topic)
+      allow(launcher).to receive(:start).and_raise(Interrupt)
+      allow(launcher).to receive(:stop)
+      allow(Eventboss::DevelopmentMode).to receive(:setup_infrastructure).with(queues)
+    end
 
     # Put the Ruby default SIGTERM signal handler back in case it matters to other tests
     after { Signal.trap 'SIGTERM', default_sigterm_signal }
 
     it 'traps SIGTERM and handles it gracefully' do
       fork_pid = fork do
-        expect(Eventboss::QueueListener).to receive(:select).and_return([queue])
+        expect(Eventboss::QueueListener).to receive(:select).and_return(queues)
         expect(client_mock).to receive(:receive_message).and_return(double(messages: [1, 2, 3]))
         expect(Eventboss).to receive(:configuration).and_return(configuration)
 
@@ -36,6 +67,23 @@ describe Eventboss::Runner do
       # Verify if fork's exist status is 0
       fork_exit_status = Process.waitall.first.last.exitstatus
       expect(fork_exit_status).to eq 0
+    end
+
+    context 'development mode' do
+      it 'is disabled by default' do
+        fork { described_class.launch }
+
+        expect(Eventboss::DevelopmentMode).not_to have_received(:setup_infrastructure).with(queues)
+      end
+
+      it "it is creating infrastructure" do
+        allow(Eventboss.configuration).to receive(:development_mode?).and_return(true)
+
+        fork do
+          described_class.launch
+          expect(Eventboss::DevelopmentMode).to have_received(:setup_infrastructure).with(queues)
+        end
+      end
     end
   end
 end

--- a/spec/eventboss/sns_client_spec.rb
+++ b/spec/eventboss/sns_client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Eventboss::SnsClient do
@@ -51,6 +53,70 @@ RSpec.describe Eventboss::SnsClient do
 
       it 'publishes to sns' do
         expect(subject).to eq(sns_response)
+      end
+    end
+  end
+
+  describe '#create_topic' do
+    subject { described_class.new(configuration).create_topic(name: '+') }
+
+    context 'for configured sns' do
+      let(:configuration) do
+        Eventboss::Configuration.new.tap do |config|
+          config.eventboss_region = 'test'
+          config.eventboss_account_id = 'test'
+          config.eventboss_app_name = 'test'
+        end
+      end
+      let(:sns_client) { instance_double(Aws::SNS::Client) }
+
+      before do
+        allow(Aws::SNS::Client).to receive(:new).and_return(sns_client)
+        allow(sns_client).to receive(:create_topic)
+      end
+
+      it 'creates new topic with a given name with sns client' do
+        subject
+        expect(sns_client).to have_received(:create_topic).with(name: '+')
+      end
+    end
+  end
+
+  describe '#create_subscription' do
+    subject do
+      described_class.new(configuration).create_subscription(topic_arn: 'TA?', queue_arn: 'QA?')
+    end
+
+    context 'for configured sns' do
+      let(:configuration) do
+        Eventboss::Configuration.new.tap do |config|
+          config.eventboss_region = 'test'
+          config.eventboss_account_id = 'test'
+          config.eventboss_app_name = 'test'
+        end
+      end
+      let(:sns_client) { instance_double(Aws::SNS::Client) }
+      let(:subscription) { double(subscription_arn: 'S?') }
+
+      before do
+        allow(Aws::SNS::Client).to receive(:new).and_return(sns_client)
+        allow(sns_client).to receive(:subscribe).and_return(subscription)
+        allow(sns_client).to receive(:set_subscription_attributes)
+      end
+
+      it 'creates subscription for topic and queue' do
+        subject
+        expect(sns_client).to have_received(:subscribe)
+          .with(endpoint: 'QA?', topic_arn: 'TA?', protocol: 'sqs')
+      end
+
+      it 'sets subscription RawMessageDelivery attribute' do
+        subject
+        expect(sns_client).to have_received(:set_subscription_attributes).with(
+          subscription_arn: subscription.subscription_arn,
+          attribute_name: 'RawMessageDelivery',
+          attribute_value: 'true'
+        )
       end
     end
   end

--- a/spec/eventboss/topic_spec.rb
+++ b/spec/eventboss/topic_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Eventboss::Topic do
+  describe '.build_arn' do
+    subject { described_class.build_arn(event_name: 'J', source_app: 'CH') }
+
+    before do
+      allow(Eventboss.configuration).to receive(:eventboss_region)
+      allow(Eventboss.configuration).to receive(:eventboss_account_id)
+      allow(Eventboss::Topic).to receive(:build_name)
+    end
+
+    it 'includes aws arn part' do
+      expect(subject).to include('arn:aws:sns')
+    end
+
+    it 'uses eventboss region' do
+      subject
+      expect(Eventboss.configuration).to have_received(:eventboss_region)
+    end
+
+    it 'uses eventboss account id' do
+      subject
+      expect(Eventboss.configuration).to have_received(:eventboss_account_id)
+    end
+
+    it 'passes params to .build_name' do
+      subject
+      expect(Eventboss::Topic).to have_received(:build_name)
+        .with(event_name: 'J', source_app: 'CH')
+    end
+
+    context 'when source app not given' do
+      subject { described_class.build_arn(event_name: 'J') }
+
+      it 'is passed as nil' do
+        subject
+        expect(Eventboss::Topic).to have_received(:build_name)
+          .with(event_name: 'J', source_app: nil)
+      end
+    end
+  end
+
+  describe '.build_name' do
+    subject { described_class.build_name(event_name: 'J', source_app: 'CH') }
+
+    before do
+      allow(Eventboss).to receive(:env)
+      allow(Eventboss.configuration).to receive(:sns_sqs_name_infix)
+    end
+
+    it 'includes required params' do
+      expect(subject).to include('CH-J')
+    end
+
+    it 'uses eventboss env' do
+      subject
+      expect(Eventboss).to have_received(:env)
+    end
+
+    it 'uses eventboss sns_sqs_name_infix' do
+      subject
+      expect(Eventboss.configuration).to have_received(:sns_sqs_name_infix)
+    end
+
+    context 'when source app not passed' do
+      subject { described_class.build_name(event_name: 'J') }
+
+      before do
+        allow(Eventboss.configuration).to receive(:sns_sqs_name_infix)
+          .and_return('infix')
+      end
+
+      it 'event name is right after the infix' do
+        expect(subject).to include('infix-J')
+      end
+    end
+  end
+end

--- a/spec/eventboss_spec.rb
+++ b/spec/eventboss_spec.rb
@@ -12,13 +12,39 @@ describe Eventboss do
     end
   end
 
+  describe '.publish' do
+    let(:sns_client) { instance_double(Eventboss::SnsClient, publish: :sns_response) }
+
+    context 'in development mode' do
+      before do
+        ENV['EVENTBUS_DEVELOPMENT_MODE'] = 'true'
+        allow(Eventboss.configuration).to receive(:sns_client).and_return(sns_client)
+        allow(Eventboss.configuration).to receive(:eventboss_app_name).and_return('app_name1')
+        allow(Eventboss::Topic).to receive(:build_name).with(event_name: 'lets-eat', source_app: 'app_name1').and_return('T')
+        allow(sns_client).to receive(:create_topic).with(name: 'T')
+      end
+
+      it 'crates topic' do
+        Eventboss.publisher('lets-eat')
+        expect(sns_client).to have_received(:create_topic).with(name: 'T')
+      end
+
+      it 'uses Topic to build topic name' do
+        Eventboss.publisher('lets-eat')
+        expect(Eventboss::Topic).to have_received(:build_name).with(event_name: 'lets-eat', source_app: 'app_name1')
+      end
+    end
+  end
+
   describe '#sender' do
     let(:event_name) { 'fake_event' }
     let(:destination_app) { 'fake_app' }
+    let(:sqs_client) { double(publish: 'sqs_response') }
     let(:configuration) do
       Eventboss::Configuration.new.tap do |c|
         c.eventboss_app_name = 'app_name1'
         c.eventboss_region = 'dummy'
+        c.sqs_client = sqs_client
       end
     end
 
@@ -26,12 +52,44 @@ describe Eventboss do
 
     before do
       allow(described_class).to receive(:configuration) { configuration }
+      allow(Eventboss.configuration).to receive(:development_mode?).and_return(false)
     end
 
     it 'calls Eventboss::Sender' do
       expect(Eventboss::Sender).to receive(:new).with(hash_including(:queue, :client))
 
       subject
+    end
+
+    context 'in development mode' do
+      let(:queue) { double(name: 'Q') }
+
+      before do
+        allow(Eventboss).to receive(:env).and_return('EV')
+        allow(Eventboss.configuration).to receive(:development_mode?).and_return(true)
+        allow(Eventboss::Queue).to receive(:build).with(
+          destination: 'dest-app',
+          event_name: 'lets-eat',
+          source_app: 'app_name1',
+          env: 'EV'
+        ).and_return(queue)
+        allow(sqs_client).to receive(:create_queue).with(queue_name: 'Q')
+      end
+
+      it 'crates queue with sqs client' do
+        Eventboss.sender('lets-eat', 'dest-app')
+        expect(sqs_client).to have_received(:create_queue).with(queue_name: 'Q')
+      end
+
+      it 'builds the Queue' do
+        Eventboss.sender('lets-eat', 'dest-app')
+        expect(Eventboss::Queue).to have_received(:build).with(hash_including(
+          destination: 'dest-app',
+          event_name: 'lets-eat',
+          source_app: 'app_name1',
+          env: 'EV'
+        ))
+      end
     end
   end
 end


### PR DESCRIPTION
#### Description
When developing an application with Eventboss one might want to test if processing messages works as expected.

Currently it requires creating needed AWS infrastructure beforehand, either through AWS IAM, via a CLI or terraform setup. 
This extra step makes for a not so smooth development experience. 

This can be mitigated by creating a setup script that creates and links required SNSes & SQSes, e.g.
https://gist.github.com/przprz/e6a445865fcfdeacb44be7186f99c498

Such a script works fine in an environment with a relaxed infrastructure policy, such as development env.  
But if the environment allows to create SNS/SQS through a script, it could as well set it up on the fly without creating a dedicated script.
This is what we call the _development mode_. 

#### In the development mode:
* [x] SNS topics required by the application are created on the fly
* [x] SQS queues are created on the fly
* [x] subscriptions are created for topics and queues
* [x] development mode must be explicitly enabled via env variable
* [x] it works™
* [x] it is covered by tests