### PR TITLE
Add destination_app option to listener eventboss_options

### DIFF
--- a/lib/eventboss/listener.rb
+++ b/lib/eventboss/listener.rb
@@ -20,8 +20,12 @@ module Eventboss
       def eventboss_options(opts)
         source_app = opts[:source_app] ? "#{opts[:source_app]}-" : ""
         event_name = opts[:event_name]
+        destination_app = opts[:destination_app]
 
-        ACTIVE_LISTENERS["#{source_app}#{event_name}"] = self
+        ACTIVE_LISTENERS["#{source_app}#{event_name}"] = {
+          listener: self,
+          destination_app: destination_app
+        }
       end
     end
   end

--- a/lib/eventboss/queue_listener.rb
+++ b/lib/eventboss/queue_listener.rb
@@ -13,17 +13,17 @@ module Eventboss
       private
 
       def list
-        Hash[Eventboss::Listener::ACTIVE_LISTENERS.map do |src_app_event, listener|
+        Hash[Eventboss::Listener::ACTIVE_LISTENERS.map do |src_app_event, opts|
           [
             Eventboss::Queue.new(
               [
-                Eventboss.configuration.eventboss_app_name,
+                opts[:destination_app] || Eventboss.configuration.eventboss_app_name,
                 Eventboss.configuration.sns_sqs_name_infix,
                 src_app_event,
                 Eventboss.env
               ].join('-')
             ),
-            listener
+            opts[:listener]
           ]
         end]
       end

--- a/spec/eventboss/listener_spec.rb
+++ b/spec/eventboss/listener_spec.rb
@@ -13,7 +13,7 @@ describe Eventboss::Listener do
     stub_const 'GenericListener1', Class.new
     GenericListener1.class_eval do
       include Eventboss::Listener
-      eventboss_options event_name: 'transaction_created'
+      eventboss_options event_name: 'transaction_created', destination_app: 'dest_app'
     end
   end
 
@@ -27,8 +27,8 @@ describe Eventboss::Listener do
   context '#ACTIVE_LISTENERS' do
     it 'adds the class to active listeners hash' do
       expect(Eventboss::Listener::ACTIVE_LISTENERS).to eq(
-        "transaction_created" => GenericListener1,
-        "app1-transaction_created" => Listener1
+        "transaction_created" => { listener: GenericListener1, destination_app: 'dest_app' },
+        "app1-transaction_created" => { listener: Listener1, destination_app: nil }
       )
     end
   end

--- a/spec/eventboss/queue_listener_spec.rb
+++ b/spec/eventboss/queue_listener_spec.rb
@@ -27,7 +27,7 @@ describe Eventboss::QueueListener do
     stub_const 'Listener3', Class.new
     Listener3.class_eval do
       include Eventboss::Listener
-      eventboss_options source_app: 'destapp3', event_name: 'file_destroyed'
+      eventboss_options source_app: 'destapp3', event_name: 'file_destroyed', destination_app: 'dest_app'
     end
   end
 
@@ -55,7 +55,7 @@ describe Eventboss::QueueListener do
           exclude: %w[Listener1 Listener2],
           include: %w[Listener2 Listener3]
         )
-        expect(queue_listeners[Eventboss::Queue.new("app1-eventboss-destapp3-file_destroyed-#{Eventboss.env}")]).to eq(Listener3)
+        expect(queue_listeners[Eventboss::Queue.new("dest_app-eventboss-destapp3-file_destroyed-#{Eventboss.env}")]).to eq(Listener3)
         expect(queue_listeners.count).to eq 1
       end
     end


### PR DESCRIPTION
I've hit 80 characters queue size limit. So I've decided to migrate application name to short one (long-name-application => LNA). During the migration I need to listen on queues with both app names such as:
```
long-name-application-eventboss-source_app-event_name-production
lna-eventboss-source_app-event_name-production
```
Right now it's not possible using eventboss. That's why I'm introducing `destination_app` option in listener.