### PR TITLE
Bring back STDOUT.sync

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.3.0)
+    eventboss (1.3.1)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)
@@ -11,7 +11,7 @@ GEM
   specs:
     aws-eventstream (1.0.3)
     aws-partitions (1.232.0)
-    aws-sdk-core (3.72.1)
+    aws-sdk-core (3.73.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.228.0)
       aws-sigv4 (~> 1.1)

--- a/bin/eventboss
+++ b/bin/eventboss
@@ -2,6 +2,8 @@
 
 require 'eventboss/cli'
 
+STDOUT.sync = true
+
 begin
   cli = Eventboss::CLI.instance
   cli.parse

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
I've removed `STDOUT.sync=true` by mistake, while adding Cli class in https://github.com/AirHelp/eventboss/pull/32
