### PR TITLE
Add listener generator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.4.0)
+    eventboss (1.3.5)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.3.5)
+    eventboss (1.3.4)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.3.4)
+    eventboss (1.4.0)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)
@@ -10,8 +10,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.0.3)
-    aws-partitions (1.281.0)
-    aws-sdk-core (3.91.0)
+    aws-partitions (1.293.0)
+    aws-sdk-core (3.92.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -19,7 +19,7 @@ GEM
     aws-sdk-sns (1.22.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.23.1)
+    aws-sdk-sqs (1.24.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.1)

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.3.4"
+  VERSION = "1.4.0"
 end

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.4.0"
+  VERSION = "1.3.4"
 end

--- a/lib/generators/eventboss/listener/eventboss_listener.rb.erb
+++ b/lib/generators/eventboss/listener/eventboss_listener.rb.erb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class <%= event_name.camelize %>Listener
+  include Eventboss::Listener
+
+  eventboss_options event_name: '<%= event_name %>'<%= source_app ? ", source_app: '#{ source_app }'" : "" %>
+
+  def receive(payload)
+    Rails.logger.tagged(jid) { Rails.logger.info("payload: #{ payload }") }
+  end
+end

--- a/lib/generators/eventboss/listener/listener_generator.rb
+++ b/lib/generators/eventboss/listener/listener_generator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Creates the Eventboss listener scaffold
+#
+# @example Invocation from terminal
+#   rails generate eventboss:listener get_well air-helper
+#
+module Eventboss
+  class ListenerGenerator < Rails::Generators::Base
+    source_root File.expand_path(__dir__)
+
+    argument :event_name, required: true
+    argument :source_app, required: false
+
+    desc 'Creates the Eventboss listener scaffold'
+    def create_listener_scaffold
+      template 'eventboss_listener.rb.erb', "app/listeners/#{ event_name }_listener.rb"
+    end
+  end
+end


### PR DESCRIPTION
Generating code is so much fun.
How about generating Eventboss listener boilerplate instead of creating it manually or copypasting?\*

Just type:
```sh
  rails g eventboss:listener get_well air-helper
```

To get:
```ruby
  # frozen_string_literal: true
  
  class GetWellListener
    include Eventboss::Listener
  
    eventboss_options event_name: 'get_well', source_app: 'air-helper'
  
    def receive(payload)
      Rails.logger.tagged(jid) { Rails.logger.info("payload: #{ payload }") }
    end
  end
```

\*so far Rails version only.


[//]: # (#### Includes:)


[//]: # (#### Related Links)
<!-- (place to add related links e.g. JIRA card) -->
<!-- (Please put all acceptance criteria and additional test notes in the JIRA card.) -->

[//]: # (#### ah-config)
<!--
Requestor/Jira: https://jira.airhelp.com/browse/
Risk (low/med/high): low
Related infrastructure/application PR link: -
Description/Why: 
-->

[//]: # (#### Related PRs)
<!-- (List of related PR in correct order) -->

[//]: # (#### Description)
<!-- (A few sentences describing the overall goals of the pull request's commits) -->

[//]: # (#### Additional deploy notes)
<!-- (Notes regarding deployment the contained body of work.) -->

[//]: # (#### Does this change any URL Paths?)
<!-- (If so, make sure that those paths won't be accessed by older emails or other apps with inbound links) -->

[//]: # (#### Screenshots)
<!-- (if appropriate) -->