### PR TITLE
Add ActiveRecord::ConnectionNotEstablished handler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.4.0)
+    eventboss (1.4.1)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)
@@ -9,23 +9,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-eventstream (1.0.3)
-    aws-partitions (1.295.0)
-    aws-sdk-core (3.93.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.350.0)
+    aws-sdk-core (3.104.3)
+      aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-sns (1.22.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-sns (1.28.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.24.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-sqs (1.30.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.1)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-sigv4 (1.2.1)
+      aws-eventstream (~> 1, >= 1.0.2)
     diff-lcs (1.3)
-    dotenv (2.7.5)
+    dotenv (2.7.6)
     jmespath (1.4.0)
     rake (13.0.1)
     rspec (3.7.0)

--- a/lib/eventboss/configuration.rb
+++ b/lib/eventboss/configuration.rb
@@ -34,6 +34,7 @@ module Eventboss
       defined_or_default('error_handlers') do
         [ErrorHandlers::Logger.new].tap do |handlers|
           handlers << ErrorHandlers::DbConnectionDropHandler.new if defined?(::ActiveRecord::StatementInvalid)
+          handlers << ErrorHandlers::DbConnectionNotEstablishedHandler.new if defined?(::ActiveRecord::ConnectionNotEstablished)
         end
       end
     end

--- a/lib/eventboss/error_handlers/db_connection_not_established_handler.rb
+++ b/lib/eventboss/error_handlers/db_connection_not_established_handler.rb
@@ -1,0 +1,11 @@
+module Eventboss
+  module ErrorHandlers
+    class DbConnectionNotEstablishedHandler
+      def call(exception, _context = {})
+        if exception.class == ::ActiveRecord::ConnectionNotEstablished
+          ::ActiveRecord::Base.connection.reconnect!
+        end
+      end
+    end
+  end
+end

--- a/lib/eventboss/extensions.rb
+++ b/lib/eventboss/extensions.rb
@@ -1,3 +1,4 @@
 require 'eventboss/error_handlers/logger'
 require 'eventboss/error_handlers/airbrake'
 require 'eventboss/error_handlers/db_connection_drop_handler'
+require 'eventboss/error_handlers/db_connection_not_established_handler'

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.4.0"
+  VERSION = "1.4.1"
 end

--- a/spec/eventboss/error_handlers/db_connection_not_established_handler_spec.rb
+++ b/spec/eventboss/error_handlers/db_connection_not_established_handler_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe Eventboss::ErrorHandlers::DbConnectionNotEstablishedHandler do
+  module ActiveRecord
+    class ConnectionNotEstablished
+    end
+
+    class Base
+      def self.connection; end
+    end
+  end
+
+  subject { described_class.new }
+
+  let(:some_error) { double(class: StandardError) }
+
+  context 'when receiving ActiveRecord::ConnectionNotEstablished exception' do
+    it 'calls AR.connection.reconnect!' do
+      expect(::ActiveRecord::Base.connection).to receive(:reconnect!)
+      subject.call(::ActiveRecord::ConnectionNotEstablished.new)
+    end
+  end
+
+  context 'when receives some other exception' do
+    it 'does not call AR.connection.reconnect!' do
+      expect(::ActiveRecord::Base.connection).to_not receive(:reconnect!)
+      subject.call(some_error)
+    end
+  end
+end


### PR DESCRIPTION
Some time ago Legal Claim Cases started throwing errors like the following one: https://errbit.ahinternal.net/apps/5936b9e1d3a45600060071fc/problems/5f1979691ce8520007ee6333
We could not identify the root cause of the problem and it just went away after a few hours.
This PR is an attempt to address it - whenever such error occurs again the app will try to reconnect to the database.