### PR TITLE
Add a Rollbar error handler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.4.1)
+    eventboss (1.5.0)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)
@@ -10,8 +10,8 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.350.0)
-    aws-sdk-core (3.104.3)
+    aws-partitions (1.374.0)
+    aws-sdk-core (3.107.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -19,10 +19,10 @@ GEM
     aws-sdk-sns (1.28.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.30.0)
+    aws-sdk-sqs (1.33.0)
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.2.1)
+    aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
     diff-lcs (1.3)
     dotenv (2.7.6)

--- a/lib/eventboss/error_handlers/rollbar.rb
+++ b/lib/eventboss/error_handlers/rollbar.rb
@@ -1,0 +1,11 @@
+module Eventboss
+  module ErrorHandlers
+    class Rollbar
+      def call(exception, context = {})
+        eventboss_context = { component: 'eventboss' }
+        eventboss_context[:action] = context[:processor].class.to_s if context[:processor]
+        ::Rollbar.error(exception, eventboss_context.merge(context))
+      end
+    end
+  end
+end

--- a/lib/eventboss/extensions.rb
+++ b/lib/eventboss/extensions.rb
@@ -1,4 +1,5 @@
 require 'eventboss/error_handlers/logger'
 require 'eventboss/error_handlers/airbrake'
+require 'eventboss/error_handlers/rollbar'
 require 'eventboss/error_handlers/db_connection_drop_handler'
 require 'eventboss/error_handlers/db_connection_not_established_handler'

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.4.1"
+  VERSION = "1.5.0"
 end

--- a/spec/eventboss/error_handlers/rollbar_handler_spec.rb
+++ b/spec/eventboss/error_handlers/rollbar_handler_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Eventboss::ErrorHandlers::Rollbar do
+  module Rollbar
+    def error(error); end
+  end
+
+  subject { described_class.new }
+
+  let(:some_error) { double(class: StandardError) }
+
+  context 'when receiving some exception' do
+    it 'calls Rollbar.error' do
+      expect(::Rollbar).to receive(:error).with(some_error, hash_including({ component: 'eventboss' }))
+      subject.call(some_error)
+    end
+  end
+end


### PR DESCRIPTION
To make the Rollbar integration easier for applications leveraging Eventboss.