### PR TITLE
Allow to define listeners with named params

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.5.1.pre.np)
+    eventboss (1.5.2.pre.np)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.5.0)
+    eventboss (1.5.1.pre.np)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       dotenv (~> 2.1, >= 2.1.1)
@@ -10,17 +10,17 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.374.0)
-    aws-sdk-core (3.107.0)
+    aws-partitions (1.427.0)
+    aws-sdk-core (3.112.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-sns (1.28.0)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-sns (1.38.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.33.0)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-sqs (1.36.0)
+      aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)

--- a/lib/eventboss/cli.rb
+++ b/lib/eventboss/cli.rb
@@ -28,7 +28,7 @@ module Eventboss
     def run
       boot_system
 
-      Eventboss.logger.info('Starting eventboss...')
+      Eventboss.logger.info("Starting eventboss v#{Eventboss::VERSION} ...")
 
       Eventboss.launch
     end

--- a/lib/eventboss/listener.rb
+++ b/lib/eventboss/listener.rb
@@ -18,6 +18,7 @@ module Eventboss
 
     module ClassMethods
       attr_reader :options
+      attr_accessor :required_params, :optional_params
 
       def eventboss_options(options)
         @options = options.compact

--- a/lib/eventboss/unit_of_work.rb
+++ b/lib/eventboss/unit_of_work.rb
@@ -12,12 +12,23 @@ module Eventboss
       @listener = listener
       @message = message
       @logger = logger
+
+      if @listener.method_defined?(:receive)
+        receive_method_params = @listener.new.method(:receive).parameters
+        if [:key, :keyreq].include?(receive_method_params[0][0])
+          @listener.required_params = receive_method_params.filter { |p| p[0] == :keyreq }.map { |p| p[1] }
+          @listener.optional_params = receive_method_params.filter { |p| p[0] == :key }.map { |p| p[1] }
+        end
+      end
     end
 
     def run
       logger.debug(@message.message_id) { 'Started' }
       processor = @listener.new
-      processor.receive(JSON.parse(@message.body))
+      JSON.parse(@message.body).tap do |payload|
+        payload = validate_and_symbolize_keys(payload, @listener.required_params, @listener.optional_params) if @listener.required_params
+        processor.receive(payload)
+      end
       logger.debug(@message.message_id) { 'Finished' }
     rescue StandardError => exception
       handle_exception(exception, processor: processor, message_id: @message.message_id)
@@ -40,6 +51,21 @@ module Eventboss
         queue_url: @queue.url, receipt_handle: @message.receipt_handle
       )
       logger.debug(@message.message_id) { 'Deleting' }
+    end
+
+    private
+
+    def validate_and_symbolize_keys(payload, required_params, optional_params)
+      {}.tap do |symbolized_payload|
+        payload.keys.each do |k|
+          symkey = k.respond_to?(:to_sym) ? k.to_sym : k
+          next unless required_params.include?(symkey) || optional_params.include?(symkey)
+          symbolized_payload[symkey] = payload[k]
+        end
+
+        missing_params = required_params - symbolized_payload.keys
+        raise ArgumentError, "Missing required params in payload #{missing_params}" if missing_params.size > 0
+      end
     end
   end
 end

--- a/lib/eventboss/unit_of_work.rb
+++ b/lib/eventboss/unit_of_work.rb
@@ -13,8 +13,9 @@ module Eventboss
       @message = message
       @logger = logger
 
-      if @listener.method_defined?(:receive)
-        receive_method_params = @listener.new.method(:receive).parameters
+      listener_instance = @listener.new
+      if listener_instance.respond_to?(:receive)
+        receive_method_params = listener_instance.method(:receive).parameters
         if [:key, :keyreq].include?(receive_method_params[0][0])
           @listener.required_params = receive_method_params.filter { |p| p[0] == :keyreq }.map { |p| p[1] }
           @listener.optional_params = receive_method_params.filter { |p| p[0] == :key }.map { |p| p[1] }

--- a/lib/eventboss/unit_of_work.rb
+++ b/lib/eventboss/unit_of_work.rb
@@ -26,8 +26,11 @@ module Eventboss
       logger.debug(@message.message_id) { 'Started' }
       processor = @listener.new
       JSON.parse(@message.body).tap do |payload|
-        payload = validate_and_symbolize_keys(payload, @listener.required_params, @listener.optional_params) if @listener.required_params
-        processor.receive(payload)
+        if @listener.required_params
+          processor.receive(**validate_and_symbolize_keys(payload, @listener.required_params, @listener.optional_params))
+        else
+          processor.receive(payload)
+        end
       end
       logger.debug(@message.message_id) { 'Finished' }
     rescue StandardError => exception

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.5.1-np"
+  VERSION = "1.5.2-np"
 end

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.5.0"
+  VERSION = "1.5.1-np"
 end

--- a/spec/eventboss/listener_spec.rb
+++ b/spec/eventboss/listener_spec.rb
@@ -15,6 +15,15 @@ describe Eventboss::Listener do
       include Eventboss::Listener
       eventboss_options event_name: 'transaction_created', destination_app: 'dest_app'
     end
+
+    stub_const 'StrongParamListener1', Class.new
+    StrongParamListener1.class_eval do
+      include Eventboss::Listener
+      eventboss_options event_name: 'strong_event', destination_app: 'dest_app'
+
+      def receive(a:, b:, c: nil)
+      end
+    end
   end
 
   context '.options' do
@@ -33,8 +42,9 @@ describe Eventboss::Listener do
   context '#ACTIVE_LISTENERS' do
     it 'adds the class to active listeners hash' do
       expect(Eventboss::Listener::ACTIVE_LISTENERS).to eq(
+        { event_name: "strong_event", destination_app: "dest_app" } => StrongParamListener1,
         { event_name: "transaction_created", destination_app: 'dest_app' } => GenericListener1,
-        { source_app: "app1", event_name: "transaction_created" } => Listener1
+        { source_app: "app1", event_name: "transaction_created" } => Listener1,
       )
     end
   end

--- a/spec/eventboss/long_poller_spec.rb
+++ b/spec/eventboss/long_poller_spec.rb
@@ -9,7 +9,14 @@ describe Eventboss::LongPoller do
   let(:bus) { [] }
   let(:client) { double('client') }
   let(:queue) { double('queue', name: 'name', url: 'url') }
-  let(:listener) { double('listener') }
+  let(:listener) do
+    Class.new do
+      include Eventboss::Listener
+
+      def receive(payload)
+      end
+    end
+  end
   let(:message) { double('message', message_id: 1) }
 
   before do

--- a/spec/eventboss/unit_of_work_spec.rb
+++ b/spec/eventboss/unit_of_work_spec.rb
@@ -135,7 +135,7 @@ describe Eventboss::UnitOfWork do
 
     context 'when correct payload' do
       let(:message) do
-        double('message', message_id: 'id', body: '{ "a": 1, "b": 2, "d": 3 }', receipt_handle: 'handle')
+        double('message', message_id: 'id', body: '{ "a": "1", "b": "2", "d": "3" }', receipt_handle: 'handle')
       end
 
       it 'deletes the job from the queue' do


### PR DESCRIPTION
A small feature that is allowing to define listeners with named parameters like:
```ruby
class SomeListener
  eventboss_options source_app: 'app1', event_name: 'transaction_created'

  def receive(some_key:, other_required_key:, other_optional_key: nil)
  end
end
```

Now if the payload is having the required keys (`some_key`, `other_required_key`) then it's automatically parsed and passed to the listeners. Optional attributes are passed if they are in the payload.

If required attributes are missing then the payload is treated as usual incorrect payload.