### PR TITLE
Deadlock fix during shutdown

### DIFF
--- a/lib/eventboss/launcher.rb
+++ b/lib/eventboss/launcher.rb
@@ -70,7 +70,7 @@ module Eventboss
     end
 
     def new_worker(id)
-      Worker.new(self, id, @bus)
+      Worker.new(self, "worker-#{id}", @bus)
     end
 
     def new_poller(queue, listener)

--- a/lib/eventboss/launcher.rb
+++ b/lib/eventboss/launcher.rb
@@ -34,6 +34,7 @@ module Eventboss
       @bus.clear
       @pollers.each(&:terminate)
       @workers.each(&:terminate)
+      @bus.close
 
       wait_for_shutdown
       hard_shutdown

--- a/lib/eventboss/long_poller.rb
+++ b/lib/eventboss/long_poller.rb
@@ -45,6 +45,8 @@ module Eventboss
       fetch_messages.each do |message|
         logger.debug(id) { "enqueueing message #{message.message_id}" }
         @bus << UnitOfWork.new(@client, queue, listener, message)
+      rescue ClosedQueueError
+        logger.info(id) { "skip message #{message.message_id} enqueuing due to closed queue" }
       end
     end
 

--- a/lib/eventboss/worker.rb
+++ b/lib/eventboss/worker.rb
@@ -7,7 +7,7 @@ module Eventboss
     attr_reader :id
 
     def initialize(launcher, id, bus, restart_on: [Exception])
-      @id = "worker-#{id}"
+      @id = id
       @launcher = launcher
       @bus = bus
       @thread = nil

--- a/lib/eventboss/worker.rb
+++ b/lib/eventboss/worker.rb
@@ -45,7 +45,6 @@ module Eventboss
     end
 
     def kill(wait = false)
-      stop_token
       return unless @thread
       @thread.raise Eventboss::Shutdown
       @thread.value if wait

--- a/spec/eventboss/long_poller_spec.rb
+++ b/spec/eventboss/long_poller_spec.rb
@@ -35,5 +35,16 @@ describe Eventboss::LongPoller do
 
       subject.fetch_and_dispatch
     end
+
+    context 'when queue is closed' do
+      before do
+        allow(bus).to receive(:<<).and_raise(ClosedQueueError)
+      end
+
+      it 'skip enqueuing the message' do
+        subject.fetch_and_dispatch
+        expect(bus.size).to be 0
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR prevents deadlock during shutdown. It seems to only appear when `worker_count` is significantly higher than `@bus` size, which is around 100.

```
INFO -- launcher: Starting 100 workers, 2 pollers

(... worker does its job ...)

INFO -- runner: Received SIGTERM signal, gracefully shutting down...
INFO -- launcher: Gracefully shutdown
INFO -- launcher: Waiting for 1 pollers, 36 workers
INFO -- launcher: Waiting for 0 pollers, 36 workers
INFO -- launcher: Waiting for 0 pollers, 36 workers
INFO -- launcher: Waiting for 0 pollers, 36 workers
INFO -- launcher: Waiting for 0 pollers, 36 workers
INFO -- launcher: Killing remaining 0 pollers, 36 workers

bundler: failed to load command: eventboss (/usr/local/bundle/bin/eventboss)
fatal: No live threads left. Deadlock?
10 threads, 10 sleeps current:0x000055ba7e5e6800 main thread:0x000055ba7c848540

* #<Thread:0x000055ba7c876d88 sleep_forever>
rb_thread_t:0x000055ba7c848540 native:0x00007f8da0340f00 int:0
/usr/local/bundle/gems/eventboss-1.5.0/lib/eventboss/worker.rb:58:in `push'
/usr/local/bundle/gems/eventboss-1.5.0/lib/eventboss/worker.rb:58:in `stop_token'
/usr/local/bundle/gems/eventboss-1.5.0/lib/eventboss/worker.rb:48:in `kill'
```

When Eventboss is shutting itself down it will do:

* set each puller stop flag
* send `stop_token` for each workers
* check 5 times every 5 second if any worker or puller left
* if so, execute #kill method on them

[`Worker#kill`](https://github.com/AirHelp/eventboss/blob/458fa92895598a6806582b114539cbe1f20ae548/lib/eventboss/worker.rb#L47) method sends [`#stop_token`](https://github.com/AirHelp/eventboss/blob/458fa92895598a6806582b114539cbe1f20ae548/lib/eventboss/worker.rb#L57) and kills the process sending `Eventboss::Shutdown` exception. It does this for every worker left. To send `#stop_token`, worker uses [`#push`](https://ruby-doc.org/core-2.7.0/SizedQueue.html#method-i-push) method (aka [<<](https://ruby-doc.org/core-2.7.0/SizedQueue.html#method-i-3C-3C)) which blocks current thread when `@bus` is full. This can lead to deadlock when no worker is available to take the `stop_token` message from a queue. When deadlock appears ruby thread system exit program with 1 as exit code and [following message](https://github.com/ruby/ruby/blob/1467328edc877ada0361e89f55158d2ed1bbb075/thread.c#L5612).

Moreover, sending `stop_token` message doesn't stop worker on which the method is executed, but a worker which receives the message from queue.

Described deadlock can be demonstrated in the following example:

```ruby
require 'set'

# set queue bufor to 10 messages
@bus = SizedQueue.new(10)
@workers = Set.new

# Creates new worker thread
# Each worker waits for a message. When a truthy message is received
# waits sleep_time. For falsy messages quits the loop, which ends thread work.
def new_worker(sleep_time)
  @workers << Thread.new { while @bus.pop; sleep sleep_time; end }
end

# Creates 10 long-run job workers
90.times { new_worker(1) }
10.times { new_worker(10) }

# Simulate work. Long-run workers will be bussy.
100.times { @bus << 1 }
# Kill short-time workers
100.times { @bus << nil }

while true
  # list dead workers
  dead_workers = @workers.filter { |worker| worker.status == false }
  puts "Dead workers: #{dead_workers.count} / #{@workers.size}"
  puts "Workers statuses: #{@workers.map { |worker| worker.status }.uniq}"

  if dead_workers.count == @workers.size
    # if all workers are dead, exit program with no error
    exit 0
  else
    # Try to kill 10 remaining workers and fill up @bus queue.
    # Method #push (<<) will block main thread waiting for
    # free spot in the queue. While no thread is left, we have deadlock.
    # Method #push will wait forever.
    # ~thread.c rb_check_deadlock(...)
    50.times { @bus << nil }
  end
  sleep 1
end
```

To prevent worker to deadlock itself, we should not send `stop_token` when taking down workers by raising an exception. Moreover, we can close the queue, which will return nil for each retrieve from the queue. This will lead to a more reliable shutdown.
