### PR TITLE
Fix params conversion in spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ lang: ruby
 
 script: bundle exec rake
 
-rvm: 2.6.5
+rvm:
+  - 2.6.5
+  - 2.7.4
+  - 3.0.2

--- a/spec/eventboss/queue_spec.rb
+++ b/spec/eventboss/queue_spec.rb
@@ -74,7 +74,7 @@ describe Eventboss::Queue do
   end
 
   describe '.build' do
-    subject { described_class.build(queue_params) }
+    subject { described_class.build(**queue_params) }
 
     let(:queue_params) do
       {


### PR DESCRIPTION
Queue spec fix. This conversion from hash to named attributes is required to pass with Ruby since 3.0.0.