### PR TITLE
Respect exception filters in rollbar handler

### DIFF
--- a/lib/eventboss/error_handlers/rollbar.rb
+++ b/lib/eventboss/error_handlers/rollbar.rb
@@ -4,7 +4,13 @@ module Eventboss
       def call(exception, context = {})
         eventboss_context = { component: 'eventboss' }
         eventboss_context[:action] = context[:processor].class.to_s if context[:processor]
-        ::Rollbar.error(exception, eventboss_context.merge(context))
+
+        default_options = { use_exception_level_filters: true }
+
+        ::Rollbar.error(
+          exception,
+          context.merge(eventboss_context, default_options)
+        )
       end
     end
   end

--- a/spec/eventboss/error_handlers/rollbar_handler_spec.rb
+++ b/spec/eventboss/error_handlers/rollbar_handler_spec.rb
@@ -14,5 +14,12 @@ describe Eventboss::ErrorHandlers::Rollbar do
       expect(::Rollbar).to receive(:error).with(some_error, hash_including({ component: 'eventboss' }))
       subject.call(some_error)
     end
+
+    it 'includes use_exception_level_filters option' do
+      option = { use_exception_level_filters: true }
+
+      expect(::Rollbar).to receive(:error).with(some_error, hash_including(option))
+      subject.call(some_error)
+    end
   end
 end


### PR DESCRIPTION
What
Since we use `Rollbar.error` to handle all exceptions that reach eventboss we want to respect setting https://docs.rollbar.com/docs/ruby#section-exception-level-filters

Why
To be able to ignore/filter exceptions that are raised in eventboss instance.