### PR TITLE
Drop dotenv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2024-03-12
+
+- Eliminate the dependency on `dotenv`. However, the application will still load `dotenv` if it is available.
+
 ## [1.4.0] - 2020-04-18
 
 - Introduce server middlewares (#31)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,16 @@
 PATH
   remote: .
   specs:
-    eventboss (1.8.1)
+    eventboss (1.9.0)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
-      dotenv (~> 2.1, >= 2.1.1)
       rexml (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.3.0)
-    aws-partitions (1.894.0)
+    aws-partitions (1.896.0)
     aws-sdk-core (3.191.3)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
@@ -26,7 +25,7 @@ GEM
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     diff-lcs (1.5.0)
-    dotenv (2.8.1)
+    dotenv (3.1.0)
     jmespath (1.6.2)
     rake (13.0.6)
     rexml (3.2.6)
@@ -49,6 +48,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (>= 1)
+  dotenv (~> 3.1)
   eventboss!
   rake (>= 10.0)
   rspec (~> 3.0)

--- a/eventboss.gemspec
+++ b/eventboss.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk-sqs", ">= 1.3.0"
   spec.add_dependency "aws-sdk-sns", ">= 1.1.0"
-  spec.add_dependency "dotenv", "~> 2.1", ">= 2.1.1"
   spec.add_dependency "rexml", "~> 3.0"
 
+  spec.add_development_dependency "dotenv", "~> 3.1"
   spec.add_development_dependency "bundler", ">= 1"
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/eventboss/cli.rb
+++ b/lib/eventboss/cli.rb
@@ -36,7 +36,7 @@ module Eventboss
     private
 
     def boot_system
-      Dotenv.load
+      Dotenv.load if defined?(Dotenv)
 
       require 'rails'
       if ::Rails::VERSION::MAJOR < 4

--- a/lib/eventboss/cli.rb
+++ b/lib/eventboss/cli.rb
@@ -1,5 +1,9 @@
 require 'rubygems'
-require 'dotenv'
+begin
+  require 'dotenv'
+  Dotenv.load
+rescue LoadError
+end
 require 'optparse'
 require 'yaml'
 require 'erb'
@@ -36,8 +40,6 @@ module Eventboss
     private
 
     def boot_system
-      Dotenv.load if defined?(Dotenv)
-
       require 'rails'
       if ::Rails::VERSION::MAJOR < 4
         require File.expand_path('config/environment.rb')

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.8.1"
+  VERSION = "1.9.0"
 end


### PR DESCRIPTION
Right now, we can't upgrade `dotenv` because of a gem conflict. So, instead of just loosening the dependency, I decided to cut it out completely. That said, if `dotenv` is around, our app will happily load it up.



This aspec was previously brought up [here](https://github.com/AirHelp/eventboss/pull/32#discussion_r337854261)

I don't know about what versions should it be/who should change it, so happy to hear how to do it