### PR TITLE
Update reporting about shutting down

### DIFF
--- a/lib/eventboss/launcher.rb
+++ b/lib/eventboss/launcher.rb
@@ -29,7 +29,7 @@ module Eventboss
     end
 
     def stop
-      logger.info('launcher') { 'Gracefully shutdown' }
+      logger.info('launcher') { 'Starting shutdown' }
 
       @bus.clear
       @pollers.each(&:terminate)
@@ -85,6 +85,8 @@ module Eventboss
         sleep shutdown_delay
         logger.info('launcher') { "Waiting for #{@pollers.size} pollers, #{@workers.size} workers" }
       end
+
+      logger.info('launcher') { 'Gracefully shutdown' }
     end
 
     def shutdown_attempts

--- a/lib/eventboss/launcher.rb
+++ b/lib/eventboss/launcher.rb
@@ -41,7 +41,10 @@ module Eventboss
     end
 
     def hard_shutdown
-      return if @pollers.empty? && @workers.empty?
+      if @poolers.empty? && @workers.empty?
+        logger.info('launcher') { 'Gracefully shutdown' }
+        return
+      end
 
       logger.info('launcher') { "Killing remaining #{@pollers.size} pollers, #{@workers.size} workers" }
       @pollers.each(&:kill)
@@ -85,8 +88,6 @@ module Eventboss
         sleep shutdown_delay
         logger.info('launcher') { "Waiting for #{@pollers.size} pollers, #{@workers.size} workers" }
       end
-
-      logger.info('launcher') { 'Gracefully shutdown' } if @pollers.empty? && @workers.empty?
     end
 
     def shutdown_attempts

--- a/lib/eventboss/launcher.rb
+++ b/lib/eventboss/launcher.rb
@@ -86,7 +86,7 @@ module Eventboss
         logger.info('launcher') { "Waiting for #{@pollers.size} pollers, #{@workers.size} workers" }
       end
 
-      logger.info('launcher') { 'Gracefully shutdown' }
+      logger.info('launcher') { 'Gracefully shutdown' } if @pollers.empty? && @workers.empty?
     end
 
     def shutdown_attempts


### PR DESCRIPTION
The message about the launcher being gracefully shut down is logged before it actually occurs, which may lead to some confusion. This PR simply rearranges the order of the messages.