### PR TITLE
Add support for AWS Session Token in development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2024-12-30
+
+- Add support for AWS Session Token in development mode
+
 ## [1.9.0] - 2024-03-12
 
 - Eliminate the dependency on `dotenv`. However, the application will still load `dotenv` if it is available.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eventboss (1.9.0)
+    eventboss (1.9.1)
       aws-sdk-sns (>= 1.1.0)
       aws-sdk-sqs (>= 1.3.0)
       rexml (~> 3.0)
@@ -10,26 +10,25 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.3.0)
-    aws-partitions (1.896.0)
-    aws-sdk-core (3.191.3)
+    aws-partitions (1.1029.0)
+    aws-sdk-core (3.214.1)
       aws-eventstream (~> 1, >= 1.3.0)
-      aws-partitions (~> 1, >= 1.651.0)
-      aws-sigv4 (~> 1.8)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-sns (1.72.0)
-      aws-sdk-core (~> 3, >= 3.191.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-sqs (1.70.0)
-      aws-sdk-core (~> 3, >= 3.191.0)
-      aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.8.0)
+    aws-sdk-sns (1.92.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sdk-sqs (1.89.0)
+      aws-sdk-core (~> 3, >= 3.210.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.10.1)
       aws-eventstream (~> 1, >= 1.0.2)
     diff-lcs (1.5.1)
     dotenv (3.1.0)
     jmespath (1.6.2)
     rake (13.0.6)
-    rexml (3.2.8)
-      strscan (>= 3.0.9)
+    rexml (3.4.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -43,7 +42,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    strscan (3.1.0)
 
 PLATFORMS
   ruby

--- a/lib/eventboss/configuration.rb
+++ b/lib/eventboss/configuration.rb
@@ -20,6 +20,7 @@ module Eventboss
       :eventboss_account_id,
       :aws_access_key_id,
       :aws_secret_access_key,
+      :aws_session_token,
       :aws_sns_endpoint,
       :aws_sqs_endpoint,
       :sns_sqs_name_infix,
@@ -63,10 +64,7 @@ module Eventboss
       defined_or_default('sqs_client') do
         options = {
           region: eventboss_region,
-          credentials: Aws::Credentials.new(
-            aws_access_key_id,
-            aws_secret_access_key
-          )
+          credentials: credentials
         }
         if aws_sqs_endpoint
           options[:endpoint] = aws_sqs_endpoint
@@ -74,6 +72,15 @@ module Eventboss
 
         Aws::SQS::Client.new(options)
       end
+    end
+
+    def credentials
+      return Aws::Credentials.new(aws_access_key_id, aws_secret_access_key, aws_session_token) if development_mode?
+        
+      Aws::Credentials.new(
+        aws_access_key_id,
+        aws_secret_access_key
+      )
     end
 
     def eventboss_region
@@ -94,6 +101,10 @@ module Eventboss
 
     def aws_secret_access_key
       defined_or_default('aws_secret_access_key') { ENV['AWS_SECRET_ACCESS_KEY'] }
+    end
+
+    def aws_session_token
+      defined_or_default('aws_session_token') { ENV['AWS_SESSION_TOKEN'] }
     end
 
     def aws_sqs_endpoint

--- a/lib/eventboss/sns_client.rb
+++ b/lib/eventboss/sns_client.rb
@@ -42,10 +42,7 @@ module Eventboss
       if configured?
         options = {
           region: configuration.eventboss_region,
-          credentials: ::Aws::Credentials.new(
-            configuration.aws_access_key_id,
-            configuration.aws_secret_access_key
-          )
+          credentials: credentials
         }
         if configuration.aws_sns_endpoint
           options[:endpoint] = configuration.aws_sns_endpoint
@@ -57,6 +54,19 @@ module Eventboss
       else
         Mock.new
       end
+    end
+
+    def credentials
+      return ::Aws::Credentials.new(
+        configuration.aws_access_key_id,
+        configuration.aws_secret_access_key,
+        configuration.aws_session_token
+      ) if configuration.development_mode?
+
+      ::Aws::Credentials.new(
+        configuration.aws_access_key_id,
+        configuration.aws_secret_access_key
+      )
     end
 
     def configured?

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.9.0"
+  VERSION = "1.9.1"
 end


### PR DESCRIPTION
After recent changes and the transition to AWS SSO, Eventboss stopped working locally with the AWS developer account. This PR adds support for temporary `AWS_ACCESS_TOKEN` credentials in development mode.