### PR TITLE
Allow to use default credentials for SNS and SQS clients

### DIFF
--- a/lib/eventboss/configuration.rb
+++ b/lib/eventboss/configuration.rb
@@ -18,6 +18,7 @@ module Eventboss
       :eventboss_region,
       :eventboss_app_name,
       :eventboss_account_id,
+      :eventboss_use_default_credentials,
       :aws_access_key_id,
       :aws_secret_access_key,
       :aws_session_token,
@@ -64,8 +65,12 @@ module Eventboss
       defined_or_default('sqs_client') do
         options = {
           region: eventboss_region,
-          credentials: credentials
         }
+
+        unless eventboss_use_default_credentials
+          options[:credentials] = credentials
+        end
+
         if aws_sqs_endpoint
           options[:endpoint] = aws_sqs_endpoint
         end
@@ -93,6 +98,10 @@ module Eventboss
 
     def eventboss_account_id
       defined_or_default('eventboss_account_id') { ENV['EVENTBOSS_ACCOUNT_ID'] || ENV['EVENTBUS_ACCOUNT_ID'] }
+    end
+
+    def eventboss_use_default_credentials
+      defined_or_default('eventboss_use_default_credentials') { ENV['EVENTBOSS_USE_DEFAULT_CREDENTIALS'] == 'true' }
     end
 
     def aws_access_key_id

--- a/lib/eventboss/sns_client.rb
+++ b/lib/eventboss/sns_client.rb
@@ -42,8 +42,12 @@ module Eventboss
       if configured?
         options = {
           region: configuration.eventboss_region,
-          credentials: credentials
         }
+
+        unless configuration.eventboss_use_default_credentials
+          options[:credentials] = credentials
+        end
+
         if configuration.aws_sns_endpoint
           options[:endpoint] = configuration.aws_sns_endpoint
         end


### PR DESCRIPTION
Credentials for SQS and SNS are being hardcoded for a specific credential method, and it does not work with new IAM roles.

In case the credentials are unspecified, AWS should try to select one of the available options.

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html#initialize-instance_method

I've thought that for now it would be safer to change this behind env variable (even if most probably it still would work without it right now). At the end if we all use IAM Roles, we can just get rid of the credentials at all. Or allow in app initializer to define it's own credentials instance