### PR TITLE
Add sentry middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.6]
+
+### Added
+- Enhanced Sentry integration
+
+### Deprecated
+- `Eventboss::ErrorHandlers::Sentry` is now deprecated in favor of `Eventboss::Sentry::ErrorHandler`
+
 ## [1.9.2] - 2025-01-21
 
 - Fix typo in instance var during shut down

--- a/README.md
+++ b/README.md
@@ -157,6 +157,23 @@ Eventboss.configure do |config|
 end
 ```
 
+### Sentry Integration
+
+Eventboss provides built-in integration with [Sentry](https://sentry.io/) for error monitoring and performance tracking. The simplest way to enable Sentry integration is to require the configuration module:
+
+```ruby
+require 'eventboss/sentry/configure'
+```
+
+For more advanced configuration options, you can manually configure the integration:
+
+```ruby
+Eventboss.configure do |config|
+  config.server_middleware.add Eventboss::Sentry::ServerMiddleware
+  config.error_handlers << Eventboss::Sentry::ErrorHandler.new
+end
+```
+
 ### Middlewares
 
 Server middlewares intercept the execution of your `Listeners`. You can use to extract and run common functions on every message received.

--- a/README.md
+++ b/README.md
@@ -165,13 +165,7 @@ Eventboss provides built-in integration with [Sentry](https://sentry.io/) for er
 require 'eventboss/sentry/configure'
 ```
 
-For more advanced configuration options, you can manually configure the integration:
-
-```ruby
-Eventboss.configure do |config|
-  config.server_middleware.add Eventboss::Sentry::ServerMiddleware
-  config.error_handlers << Eventboss::Sentry::ErrorHandler.new
-end
+For more advanced configuration options, you can manually configure the integration. Please inspect [lib/eventboss/sentry/configure.rb](lib/eventboss/sentry/configure.rb) to see options.
 ```
 
 ### Middlewares

--- a/eventboss.gemspec
+++ b/eventboss.gemspec
@@ -28,5 +28,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1"
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "sentry-ruby"
 end

--- a/eventboss.gemspec
+++ b/eventboss.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1"
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "sentry-ruby"
 end

--- a/lib/eventboss/error_handlers/sentry.rb
+++ b/lib/eventboss/error_handlers/sentry.rb
@@ -7,6 +7,8 @@ module Eventboss
              "For automatic configuration, require 'eventboss/sentry/configure'. " \
              "This class will be removed in a future version."
         super
+      end
+
       def call(exception, context = {})
         eventboss_context = { component: 'eventboss' }
         eventboss_context[:action] = context[:processor].class.to_s if context[:processor]

--- a/lib/eventboss/error_handlers/sentry.rb
+++ b/lib/eventboss/error_handlers/sentry.rb
@@ -1,6 +1,12 @@
 module Eventboss
   module ErrorHandlers
     class Sentry
+      def initialize
+        warn "[DEPRECATED] Eventboss::ErrorHandlers::Sentry is deprecated. " \
+             "Use Eventboss::Sentry::ErrorHandler instead. " \
+             "For automatic configuration, require 'eventboss/sentry/configure'. " \
+             "This class will be removed in a future version."
+        super
       def call(exception, context = {})
         eventboss_context = { component: 'eventboss' }
         eventboss_context[:action] = context[:processor].class.to_s if context[:processor]

--- a/lib/eventboss/long_poller.rb
+++ b/lib/eventboss/long_poller.rb
@@ -74,7 +74,8 @@ module Eventboss
         queue_url: queue.url,
         max_number_of_messages: 10,
         wait_time_seconds: TIME_WAIT,
-        attribute_names: ['SentTimestamp', 'ApproximateReceiveCount']
+        attribute_names: ['SentTimestamp', 'ApproximateReceiveCount'],
+        message_attribute_names: ['sentry-trace', 'baggage', 'sentry_user']
       ).messages
     end
   end

--- a/lib/eventboss/long_poller.rb
+++ b/lib/eventboss/long_poller.rb
@@ -73,7 +73,8 @@ module Eventboss
       @client.receive_message(
         queue_url: queue.url,
         max_number_of_messages: 10,
-        wait_time_seconds: TIME_WAIT
+        wait_time_seconds: TIME_WAIT,
+        attribute_names: ['SentTimestamp', 'ApproximateReceiveCount']
       ).messages
     end
   end

--- a/lib/eventboss/publisher.rb
+++ b/lib/eventboss/publisher.rb
@@ -10,6 +10,28 @@ module Eventboss
     end
 
     def publish(payload)
+      if defined?(::Eventboss::Sentry::Integration) && ::Sentry.initialized?
+        publish_with_sentry(payload)
+      else
+        publish_without_sentry(payload)
+      end
+    end
+
+    private
+
+    def publish_with_sentry(payload)
+      topic_arn = Topic.build_arn(event_name: event_name, source_app: source)
+
+      ::Sentry.with_child_span(op: "queue.publish", description: "#{source}##{event_name}") do
+        sns_client.publish(
+          topic_arn: topic_arn,
+          message: json_payload(payload),
+          message_attributes: build_sentry_message_attributes
+        )
+      end
+    end
+
+    def publish_without_sentry(payload)
       topic_arn = Topic.build_arn(event_name: event_name, source_app: source)
       sns_client.publish(
         topic_arn: topic_arn,
@@ -23,6 +45,17 @@ module Eventboss
 
     def json_payload(payload)
       payload.is_a?(String) ? payload : payload.to_json
+    end
+
+    def build_sentry_message_attributes
+      attributes = ::Sentry.get_trace_propagation_headers
+                           .slice('sentry-trace', 'baggage')
+                           .transform_values do |header_value|
+        { string_value: header_value, data_type: 'String' }
+      end
+      user = ::Sentry.get_current_scope.user
+      attributes['sentry_user'] = user unless user.empty?
+      attributes
     end
   end
 end

--- a/lib/eventboss/publisher.rb
+++ b/lib/eventboss/publisher.rb
@@ -54,7 +54,12 @@ module Eventboss
         { string_value: header_value, data_type: 'String' }
       end
       user = ::Sentry.get_current_scope.user
-      attributes['sentry_user'] = user unless user.empty?
+      if user && !user.empty?
+        attributes['sentry_user'] = {
+          string_value: user.to_json,
+          data_type: 'String'
+        }
+      end
       attributes
     end
   end

--- a/lib/eventboss/publisher.rb
+++ b/lib/eventboss/publisher.rb
@@ -22,7 +22,7 @@ module Eventboss
     def publish_with_sentry(payload)
       topic_arn = Topic.build_arn(event_name: event_name, source_app: source)
 
-      ::Sentry.with_child_span(op: "queue.publish", description: "#{source}##{event_name}") do
+      ::Sentry.with_child_span(op: "queue.publish", description: "Eventboss push #{source}/#{event_name}") do
         sns_client.publish(
           topic_arn: topic_arn,
           message: json_payload(payload),

--- a/lib/eventboss/publisher.rb
+++ b/lib/eventboss/publisher.rb
@@ -9,57 +9,68 @@ module Eventboss
       @source = configuration.eventboss_app_name unless opts[:generic]
     end
 
+    # Publishes the payload to the SNS topic.
+    # If Sentry is enabled, it wraps the publish action in a Sentry span for tracing.
     def publish(payload)
-      if defined?(::Eventboss::Sentry::Integration) && ::Sentry.initialized?
-        publish_with_sentry(payload)
+      sns_params = build_sns_params(payload)
+      publisher_action = -> { sns_client.publish(sns_params) }
+
+      if sentry_enabled?
+        with_sentry_span(&publisher_action)
       else
-        publish_without_sentry(payload)
+        publisher_action.call
       end
-    end
-
-    private
-
-    def publish_with_sentry(payload)
-      topic_arn = Topic.build_arn(event_name: event_name, source_app: source)
-
-      ::Sentry.with_child_span(op: "queue.publish", description: "Eventboss push #{source}/#{event_name}") do
-        sns_client.publish(
-          topic_arn: topic_arn,
-          message: json_payload(payload),
-          message_attributes: build_sentry_message_attributes
-        )
-      end
-    end
-
-    def publish_without_sentry(payload)
-      topic_arn = Topic.build_arn(event_name: event_name, source_app: source)
-      sns_client.publish(
-        topic_arn: topic_arn,
-        message: json_payload(payload)
-      )
     end
 
     private
 
     attr_reader :event_name, :sns_client, :configuration, :source
 
+    def sentry_enabled?
+      defined?(::Eventboss::Sentry::Integration) && ::Sentry.initialized?
+    end
+
+    def build_sns_params(payload)
+      {
+        topic_arn: Topic.build_arn(event_name: event_name, source_app: source),
+        message: json_payload(payload),
+        message_attributes: sentry_enabled? ? build_sentry_message_attributes : {}
+      }
+    end
+
+    def with_sentry_span
+      queue_name = Queue.build_name(destination: source, event_name: event_name, env: Eventboss.env, source_app: source)
+
+      ::Sentry.with_child_span(op: 'queue.publish', description: "Eventboss push #{source}/#{event_name}") do |span|
+        span.set_data(::Sentry::Span::DataConventions::MESSAGING_DESTINATION_NAME, Eventboss::Sentry::ServerMiddleware::QUEUES_WITHOUT_ENV[queue_name])
+
+        message = yield # Executes the publisher_action lambda
+
+        span.set_data(::Sentry::Span::DataConventions::MESSAGING_MESSAGE_ID, message.message_id)
+        message
+      end
+    end
+
     def json_payload(payload)
       payload.is_a?(String) ? payload : payload.to_json
     end
 
+    # Constructs SNS message attributes for Sentry trace propagation.
     def build_sentry_message_attributes
       attributes = ::Sentry.get_trace_propagation_headers
                            .slice('sentry-trace', 'baggage')
                            .transform_values do |header_value|
         { string_value: header_value, data_type: 'String' }
       end
-      user = ::Sentry.get_current_scope.user
+
+      user = ::Sentry.get_current_scope&.user
       if user && !user.empty?
         attributes['sentry_user'] = {
           string_value: user.to_json,
           data_type: 'String'
         }
       end
+
       attributes
     end
   end

--- a/lib/eventboss/publisher.rb
+++ b/lib/eventboss/publisher.rb
@@ -9,16 +9,9 @@ module Eventboss
       @source = configuration.eventboss_app_name unless opts[:generic]
     end
 
-    # Publishes the payload to the SNS topic.
-    # If Sentry is enabled, it wraps the publish action in a Sentry span for tracing.
     def publish(payload)
-      sns_params = build_sns_params(payload)
-      publisher_action = -> { sns_client.publish(**sns_params) }
-
-      if sentry_enabled?
-        with_sentry_span(&publisher_action)
-      else
-        publisher_action.call
+      with_sentry_span do
+        sns_client.publish(**build_sns_params(payload))
       end
     end
 
@@ -34,17 +27,19 @@ module Eventboss
       {
         topic_arn: Topic.build_arn(event_name: event_name, source_app: source),
         message: json_payload(payload),
-        message_attributes: sentry_enabled? ? build_sentry_message_attributes : {}
+        message_attributes: sentry_enabled? ? build_sns_message_attributes : {}
       }
     end
 
     def with_sentry_span
+      return yield unless sentry_enabled?
+
       queue_name = Queue.build_name(destination: source, event_name: event_name, env: Eventboss.env, source_app: source)
 
       ::Sentry.with_child_span(op: 'queue.publish', description: "Eventboss push #{source}/#{event_name}") do |span|
-        span.set_data(::Sentry::Span::DataConventions::MESSAGING_DESTINATION_NAME, Eventboss::Sentry::ServerMiddleware::QUEUES_WITHOUT_ENV[queue_name])
+        span.set_data(::Sentry::Span::DataConventions::MESSAGING_DESTINATION_NAME, ::Eventboss::Sentry::Context.queue_name_for_sentry(queue_name))
 
-        message = yield # Executes the publisher_action lambda
+        message = yield
 
         span.set_data(::Sentry::Span::DataConventions::MESSAGING_MESSAGE_ID, message.message_id)
         message
@@ -55,23 +50,8 @@ module Eventboss
       payload.is_a?(String) ? payload : payload.to_json
     end
 
-    # Constructs SNS message attributes for Sentry trace propagation.
-    def build_sentry_message_attributes
-      attributes = ::Sentry.get_trace_propagation_headers
-                           .slice('sentry-trace', 'baggage')
-                           .transform_values do |header_value|
-        { string_value: header_value, data_type: 'String' }
-      end
-
-      user = ::Sentry.get_current_scope&.user
-      if user && !user.empty?
-        attributes['sentry_user'] = {
-          string_value: user.to_json,
-          data_type: 'String'
-        }
-      end
-
-      attributes
+    def build_sns_message_attributes
+      ::Eventboss::Sentry::Context.build_sns_message_attributes
     end
   end
 end

--- a/lib/eventboss/publisher.rb
+++ b/lib/eventboss/publisher.rb
@@ -13,7 +13,7 @@ module Eventboss
     # If Sentry is enabled, it wraps the publish action in a Sentry span for tracing.
     def publish(payload)
       sns_params = build_sns_params(payload)
-      publisher_action = -> { sns_client.publish(sns_params) }
+      publisher_action = -> { sns_client.publish(**sns_params) }
 
       if sentry_enabled?
         with_sentry_span(&publisher_action)

--- a/lib/eventboss/sentry/configure.rb
+++ b/lib/eventboss/sentry/configure.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative 'integration'
+
+# Auto configure eventboss to use sentry
+
+Eventboss.configure do |config|
+  config.server_middleware.add Eventboss::Sentry::ServerMiddleware
+  config.error_handlers << Eventboss::Sentry::ErrorHandler.new
+end
+

--- a/lib/eventboss/sentry/context.rb
+++ b/lib/eventboss/sentry/context.rb
@@ -1,0 +1,35 @@
+module Eventboss
+  module Sentry
+    class Context
+      # since sentry has env selector, we can remove it from queue names
+      QUEUES_WITHOUT_ENV = Hash.new do |hash, key|
+        hash[key] = key
+                      .gsub(/-#{Eventboss.env}-deadletter$/, '-ENV-deadletter')
+                      .gsub(/-#{Eventboss.env}$/, '-ENV')
+      end
+
+      def self.queue_name_for_sentry(queue_name)
+        QUEUES_WITHOUT_ENV[queue_name]
+      end
+
+      # Constructs SNS message attributes for Sentry trace propagation.
+      def self.build_sns_message_attributes
+        attributes = ::Sentry.get_trace_propagation_headers
+                             .slice('sentry-trace', 'baggage')
+                             .transform_values do |header_value|
+          { string_value: header_value, data_type: 'String' }
+        end
+
+        user = ::Sentry.get_current_scope&.user
+        if user && !user.empty?
+          attributes['sentry_user'] = {
+            string_value: user.to_json,
+            data_type: 'String'
+          }
+        end
+
+        attributes
+      end
+    end
+  end
+end

--- a/lib/eventboss/sentry/error_handler.rb
+++ b/lib/eventboss/sentry/error_handler.rb
@@ -1,0 +1,15 @@
+module Eventboss
+  module Sentry
+    class ErrorHandler
+      def call(exception, _context = {})
+        return unless ::Sentry.initialized?
+
+        Eventboss::Sentry::Integration.capture_exception(
+          exception,
+          contexts: { eventboss: { } },
+          hint: { background: false }
+        )
+      end
+    end
+  end
+end

--- a/lib/eventboss/sentry/integration.rb
+++ b/lib/eventboss/sentry/integration.rb
@@ -1,6 +1,7 @@
 require 'sentry-ruby'
 require 'sentry/integrable'
 require_relative 'error_handler'
+require_relative 'context'
 require_relative 'server_middleware'
 
 module Eventboss

--- a/lib/eventboss/sentry/integration.rb
+++ b/lib/eventboss/sentry/integration.rb
@@ -1,0 +1,14 @@
+require 'sentry-ruby'
+require 'sentry/integrable'
+require_relative 'error_handler'
+require_relative 'server_middleware'
+
+module Eventboss
+  module Sentry
+    class Integration
+      extend ::Sentry::Integrable
+
+      register_integration name: "eventboss", version: Eventboss::VERSION
+    end
+  end
+end

--- a/lib/eventboss/sentry/server_middleware.rb
+++ b/lib/eventboss/sentry/server_middleware.rb
@@ -7,8 +7,8 @@ module Eventboss
       # since sentry has env selector, we can remove it from queue names
       QUEUES_WITHOUT_ENV = Hash.new do |hash, key|
         hash[key] = key
-                      .gsub("-#{Eventboss.env}-", '-ENV-')
-                      .gsub("-#{Eventboss.env}", '-ENV')
+                      .gsub(/-#{Eventboss.env}-deadletter$/, '-ENV-deadletter')
+                      .gsub(/-#{Eventboss.env}$/, '-ENV')
       end
 
       def call(work)

--- a/lib/eventboss/sentry/server_middleware.rb
+++ b/lib/eventboss/sentry/server_middleware.rb
@@ -11,7 +11,7 @@ module Eventboss
         scope = ::Sentry.get_current_scope
         scope.clear
         scope.set_tags(queue: work.queue.name, message_id: work.message.message_id)
-        scope.set_transaction_name(work.listener.to_s, source: :task)
+        scope.set_transaction_name(extract_transaction_name(work), source: :task)
         transaction = start_transaction(scope)
 
         if transaction
@@ -56,6 +56,9 @@ module Eventboss
         transaction.finish
       end
 
+      def extract_transaction_name(work)
+        "Eventboss/#{work.listener.to_s}"
+      end
       def extract_latency(message)
         if sent_timestamp = message.attributes.fetch('SentTimestamp', nil)
           Time.now - Time.at(sent_timestamp.to_i / 1000.0)

--- a/lib/eventboss/sentry/server_middleware.rb
+++ b/lib/eventboss/sentry/server_middleware.rb
@@ -1,0 +1,72 @@
+module Eventboss
+  module Sentry
+    class ServerMiddleware < Eventboss::Middleware::Base
+      OP_NAME = 'queue.process'
+      SPAN_ORIGIN = 'auto.queue.eventboss'
+
+      def call(work)
+        return yield unless ::Sentry.initialized?
+
+        ::Sentry.clone_hub_to_current_thread
+        scope = ::Sentry.get_current_scope
+        scope.clear
+        scope.set_tags(queue: work.queue.name, message_id: work.message.message_id)
+        scope.set_transaction_name(work.listener.to_s, source: :task)
+        transaction = start_transaction(scope)
+
+        if transaction
+          scope.set_span(transaction)
+          transaction.set_data(::Sentry::Span::DataConventions::MESSAGING_MESSAGE_ID, work.message.message_id)
+          transaction.set_data(::Sentry::Span::DataConventions::MESSAGING_DESTINATION_NAME, work.queue.name)
+
+          if (latency = extract_latency(work.message))
+            transaction.set_data(::Sentry::Span::DataConventions::MESSAGING_MESSAGE_RECEIVE_LATENCY, latency)
+          end
+
+          if (retry_count = extract_receive_count(work.message))
+            transaction.set_data(::Sentry::Span::DataConventions::MESSAGING_MESSAGE_RETRY_COUNT, retry_count)
+          end
+        end
+
+        begin
+          yield
+        rescue StandardError
+          finish_transaction(transaction, 500)
+          raise
+        end
+
+        finish_transaction(transaction, 200)
+      end
+
+      def start_transaction(scope)
+        options = {
+          name: scope.transaction_name,
+          source: scope.transaction_source,
+          op: OP_NAME,
+          origin: SPAN_ORIGIN
+        }
+
+        ::Sentry.start_transaction(**options)
+      end
+
+      def finish_transaction(transaction, status)
+        return unless transaction
+
+        transaction.set_http_status(status)
+        transaction.finish
+      end
+
+      def extract_latency(message)
+        if sent_timestamp = message.attributes.fetch('SentTimestamp', nil)
+          Time.now - Time.at(sent_timestamp.to_i / 1000.0)
+        end
+      end
+
+      def extract_receive_count(message)
+        if receive_count = message.attributes.fetch('ApproximateReceiveCount', nil)
+          receive_count.to_i - 1
+        end
+      end
+    end
+  end
+end

--- a/lib/eventboss/sentry/server_middleware.rb
+++ b/lib/eventboss/sentry/server_middleware.rb
@@ -7,8 +7,8 @@ module Eventboss
       # since sentry has env selector, we can remove it from queue names
       QUEUES_WITHOUT_ENV = Hash.new do |hash, key|
         hash[key] = key
-                      .gsub("-#{Eventboss.env}-", '')
-                      .gsub("-#{Eventboss.env}", '')
+                      .gsub("-#{Eventboss.env}-", '-ENV-')
+                      .gsub("-#{Eventboss.env}", '-ENV')
       end
 
       def call(work)

--- a/lib/eventboss/sentry/server_middleware.rb
+++ b/lib/eventboss/sentry/server_middleware.rb
@@ -4,13 +4,6 @@ module Eventboss
       OP_NAME = 'queue.process'
       SPAN_ORIGIN = 'auto.queue.eventboss'
 
-      # since sentry has env selector, we can remove it from queue names
-      QUEUES_WITHOUT_ENV = Hash.new do |hash, key|
-        hash[key] = key
-                      .gsub(/-#{Eventboss.env}-deadletter$/, '-ENV-deadletter')
-                      .gsub(/-#{Eventboss.env}$/, '-ENV')
-      end
-
       def call(work)
         return yield unless ::Sentry.initialized?
 
@@ -83,7 +76,7 @@ module Eventboss
       end
 
       def extract_queue_name(work)
-        QUEUES_WITHOUT_ENV[work.queue.name]
+        ::Eventboss::Sentry::Context.queue_name_for_sentry(work.queue.name)
       end
 
       def extract_latency(message)

--- a/lib/eventboss/sentry/server_middleware.rb
+++ b/lib/eventboss/sentry/server_middleware.rb
@@ -73,7 +73,9 @@ module Eventboss
       end
 
       def extract_sentry_user(work)
-        work.message.message_attributes["sentry_user"]&.string_value
+        if (value = work.message.message_attributes["sentry_user"]&.string_value)
+          JSON.parse(value)
+        end
       end
 
       def extract_transaction_name(work)

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.9.5"
+  VERSION = "1.9.6"
 end

--- a/spec/eventboss/long_poller_spec.rb
+++ b/spec/eventboss/long_poller_spec.rb
@@ -32,7 +32,8 @@ describe Eventboss::LongPoller do
     it 'calls client with proper attributes' do
       expect(client).to receive(:receive_message)
         .with(queue_url: 'url', max_number_of_messages: 10, wait_time_seconds: 10,
-              attribute_names: ["SentTimestamp", "ApproximateReceiveCount"])
+              attribute_names: ["SentTimestamp", "ApproximateReceiveCount"],
+              message_attribute_names: ["sentry-trace", "baggage", "sentry_user"])
 
       subject.fetch_and_dispatch
     end

--- a/spec/eventboss/long_poller_spec.rb
+++ b/spec/eventboss/long_poller_spec.rb
@@ -31,7 +31,8 @@ describe Eventboss::LongPoller do
 
     it 'calls client with proper attributes' do
       expect(client).to receive(:receive_message)
-        .with(queue_url: 'url', max_number_of_messages: 10, wait_time_seconds: 10)
+        .with(queue_url: 'url', max_number_of_messages: 10, wait_time_seconds: 10,
+              attribute_names: ["SentTimestamp", "ApproximateReceiveCount"])
 
       subject.fetch_and_dispatch
     end

--- a/spec/eventboss/publisher_spec.rb
+++ b/spec/eventboss/publisher_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Eventboss::Publisher do
     it 'publishes to sns with source app name by default' do
       expect(sns_client).to receive(:publish).with(
         topic_arn: "arn:aws:sns:::eventboss-app_name1-event_name-ping",
-        message: "{}"
+        message: "{}",
+        message_attributes: {}
       )
       expect(subject).to eq(sns_response)
     end
@@ -53,7 +54,8 @@ RSpec.describe Eventboss::Publisher do
       it 'publishes to sns without app name' do
         expect(sns_client).to receive(:publish).with(
           topic_arn: "arn:aws:sns:::eventboss-event_name-ping",
-          message: "{}"
+          message: "{}",
+          message_attributes: {}
         )
         subject
       end


### PR DESCRIPTION
This PR introduces Sentry for Eventboss with performance monitoring, distributed tracing, and enhanced error reporting.

The new `Eventboss::Sentry::ServerMiddleware` creates transactions for message processing witg context (queue names, message IDs, latency, retry counts)

Simple one-line setup via `require 'eventboss/sentry/configure'` automatically configures both client and server components. The old Eventboss::ErrorHandlers::Sentry is deprecated


To see it working please see: https://airhelp.sentry.io/insights/backend/queues/?environment=staging&project=4506716776693760&statsPeriod=1h

This branch is currently on staging & production. The staging has newest version deployed ~1h ago

<img width="1613" height="536" alt="Screenshot 2025-08-20 at 08 51 51" src="https://github.com/user-attachments/assets/b8306413-b026-4f45-be78-7fbfe9b2e3fc" />


This middleware is based on [sidekiq integration ](https://github.com/getsentry/sentry-ruby/blob/master/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb)

Later i saw this [we have](https://github.com/AirHelp/ah-cockpit/blob/5d94d4191c621d45d6ce7462fe3f4d6c1aa4783a/lib/sentry/eventboss/sentry_context_middleware.rb) in Airhelp already a custome one  :D But it is lacking features