### PR TITLE
[ROMEO-457] Fix NoMethodError in sentry integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.7]
+
+- Fix undefined method 'set_data' for nil span in Sentry integration
+
 ## [1.9.6]
 
 ### Added

--- a/lib/eventboss/publisher.rb
+++ b/lib/eventboss/publisher.rb
@@ -37,11 +37,11 @@ module Eventboss
       queue_name = Queue.build_name(destination: source, event_name: event_name, env: Eventboss.env, source_app: source)
 
       ::Sentry.with_child_span(op: 'queue.publish', description: "Eventboss push #{source}/#{event_name}") do |span|
-        span.set_data(::Sentry::Span::DataConventions::MESSAGING_DESTINATION_NAME, ::Eventboss::Sentry::Context.queue_name_for_sentry(queue_name))
+        span.set_data(::Sentry::Span::DataConventions::MESSAGING_DESTINATION_NAME, ::Eventboss::Sentry::Context.queue_name_for_sentry(queue_name)) if span
 
         message = yield
 
-        span.set_data(::Sentry::Span::DataConventions::MESSAGING_MESSAGE_ID, message.message_id)
+        span.set_data(::Sentry::Span::DataConventions::MESSAGING_MESSAGE_ID, message.message_id) if span
         message
       end
     end

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.9.6"
+  VERSION = "1.9.7"
 end


### PR DESCRIPTION
Fixes [undefined method 'set_data' for nil (NoMethodError) span.set_data](https://airhelp.sentry.io/issues/6823402020/?alert_rule_id=14996423&alert_type=issue&environment=staging&notification_uuid=d542bf41-e4bb-4b54-a13b-fc00418e056f&project=4506716776693760&referrer=slack)  

Also in [sidekiq integration](https://github.com/getsentry/sentry-ruby/blob/master/sentry-sidekiq/lib/sentry/sidekiq/sentry_context_middleware.rb#L9) there are checks if it's nil 