### PR TITLE
Memoize SNS client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.9.8]
+
+- Improve performance by reusing SNS client
+
 ## [1.9.7]
 
 - Fix undefined method 'set_data' for nil span in Sentry integration

--- a/lib/eventboss/sns_client.rb
+++ b/lib/eventboss/sns_client.rb
@@ -39,27 +39,22 @@ module Eventboss
     end
 
     def backend
-      @backend ||= begin
-                     if configured?
-                       options = {
-                         region: configuration.eventboss_region,
-                       }
+      @backend ||=
+        if configured?
+          options = {
+            region: configuration.eventboss_region
+          }
 
-                       unless configuration.eventboss_use_default_credentials
-                         options[:credentials] = credentials
-                       end
+          options[:credentials] = credentials unless configuration.eventboss_use_default_credentials
 
-                       if configuration.aws_sns_endpoint
-                         options[:endpoint] = configuration.aws_sns_endpoint
-                       end
+          options[:endpoint] = configuration.aws_sns_endpoint if configuration.aws_sns_endpoint
 
-                       Aws::SNS::Client.new(options)
-                     elsif configuration.raise_on_missing_configuration
-                       raise NotConfigured, 'Eventboss is not configured.'
-                     else
-                       Mock.new
-                     end
-                   end
+          Aws::SNS::Client.new(options)
+        elsif configuration.raise_on_missing_configuration
+          raise NotConfigured, 'Eventboss is not configured.'
+        else
+          Mock.new
+        end
     end
 
     def credentials

--- a/lib/eventboss/sns_client.rb
+++ b/lib/eventboss/sns_client.rb
@@ -39,25 +39,27 @@ module Eventboss
     end
 
     def backend
-      if configured?
-        options = {
-          region: configuration.eventboss_region,
-        }
+      @backend ||= begin
+                     if configured?
+                       options = {
+                         region: configuration.eventboss_region,
+                       }
 
-        unless configuration.eventboss_use_default_credentials
-          options[:credentials] = credentials
-        end
+                       unless configuration.eventboss_use_default_credentials
+                         options[:credentials] = credentials
+                       end
 
-        if configuration.aws_sns_endpoint
-          options[:endpoint] = configuration.aws_sns_endpoint
-        end
+                       if configuration.aws_sns_endpoint
+                         options[:endpoint] = configuration.aws_sns_endpoint
+                       end
 
-        Aws::SNS::Client.new(options)
-      elsif configuration.raise_on_missing_configuration
-        raise NotConfigured, 'Eventboss is not configured.'
-      else
-        Mock.new
-      end
+                       Aws::SNS::Client.new(options)
+                     elsif configuration.raise_on_missing_configuration
+                       raise NotConfigured, 'Eventboss is not configured.'
+                     else
+                       Mock.new
+                     end
+                   end
     end
 
     def credentials

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.9.7"
+  VERSION = "1.9.8"
 end


### PR DESCRIPTION
For sending a message:
```
3.4.3 :006 > 2.times {   TestPublisher.new.call({ event_data: "some value" }) }
getting backend..
getting backend..
getting backend..
getting backend..
```

the backend was called multiple times - each time initialising a new SNS client


Its used in ahplus-rails https://github.com/AirHelp/ahplus-rails/blob/master/Gemfile#L98