### PR TITLE
[ROMEO-1265] Exit cleanly on SIGTERM received during boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.9.9]
+
+### Fixed
+- Exit cleanly on SIGTERM received during application boot, before the runner installs its graceful signal handling, so a shutdown mid-boot is no longer reported as a crash
+
 ## [1.9.8]
 
 - Improve performance by reusing SNS client

--- a/lib/eventboss/cli.rb
+++ b/lib/eventboss/cli.rb
@@ -30,6 +30,8 @@ module Eventboss
     end
 
     def run
+      setup_boot_signal_traps
+
       boot_system
 
       Eventboss.logger.info('Starting eventboss...')
@@ -38,6 +40,15 @@ module Eventboss
     end
 
     private
+
+    # Booting the application (e.g. loading Rails) can take long enough that a
+    # termination signal arrives before Runner installs its graceful signal
+    # handling. Without a handler the process dies non-gracefully and is
+    # reported as a crash. Until Runner takes over, exit cleanly on SIGTERM so
+    # a shutdown mid-boot is not treated as a failure.
+    def setup_boot_signal_traps
+      Signal.trap('SIGTERM') { exit 0 }
+    end
 
     def boot_system
       require 'rails'

--- a/lib/eventboss/version.rb
+++ b/lib/eventboss/version.rb
@@ -1,3 +1,3 @@
 module Eventboss
-  VERSION = "1.9.8"
+  VERSION = "1.9.9"
 end

--- a/spec/eventboss/cli_spec.rb
+++ b/spec/eventboss/cli_spec.rb
@@ -102,5 +102,34 @@ RSpec.describe Eventboss::CLI do
         expect { subject.run }.to raise_error LoadError
       end
     end
+
+    describe 'when SIGTERM is received during boot' do
+      let(:default_sigterm_signal) { Signal.trap 'SIGTERM', 'SYSTEM_DEFAULT' }
+
+      after { Signal.trap 'SIGTERM', default_sigterm_signal }
+
+      it 'exits with status 0 instead of crashing' do
+        reader, writer = IO.pipe
+
+        pid = fork do
+          reader.close
+          allow(subject).to receive(:boot_system) do
+            writer.puts 'booting'
+            sleep 5
+          end
+          allow(Eventboss).to receive(:launch)
+
+          subject.run
+        end
+
+        writer.close
+        reader.gets
+
+        Process.kill 'SIGTERM', pid
+        _, status = Process.wait2(pid)
+
+        expect(status.exitstatus).to eq 0
+      end
+    end
   end
 end


### PR DESCRIPTION
## Issue

Workers that are scaled to zero get resurrected by a deploy (the chart applies `replicas: 1`), then the autoscaler's 30s probe sees an empty queue and scales them back down. The SIGTERM therefore lands at pod age ~10–20s — while the app is still booting.

`CLI#run` boots the application *before* any signal handling exists:

```ruby
def run
  boot_system                 # loading Rails takes ~17s in our app
  Eventboss.logger.info('Starting eventboss...')
  Eventboss.launch            # Runner#setup_signals installs traps in here
end
```

A SIGTERM arriving in that window hits no handler at all, so the process dies from the default disposition. `bin/eventboss` wraps everything in `rescue => e ... exit 1`, so the orchestrator sees a non-zero exit and reports a crash — for us that means an SMS page for what is actually an ordinary, harmless scale-down.

This is not specific to the autoscaler: any mid-boot SIGTERM does it (Spot reclaim, node drain, rebalancing, `kubectl rollout restart`).

### Why not copy this from Sidekiq

It was suggested that since eventboss borrowed its signal handling from Sidekiq, we could transplant Sidekiq's solution. Sidekiq has the same gap — [`lib/sidekiq/cli.rb#L42-L68`](https://github.com/sidekiq/sidekiq/blob/3ab01da03a71b3c94a36f3a2f84976cbc36b6d0d/lib/sidekiq/cli.rb#L42-L68): `boot_application` is line 43, the `IO.pipe` + `Signal.trap` loop only starts at line 50. Sidekiq just doesn't get bitten in practice, because its workers aren't usually scaled to zero seconds after starting. The self-pipe pattern eventboss already copied into `Runner#setup_signals` *is* the Sidekiq code — same code, same place relative to boot.

## Solution

Install a minimal SIGTERM trap before booting:

```ruby
def run
  setup_boot_signal_traps
  boot_system
  ...
  Eventboss.launch
end

def setup_boot_signal_traps
  Signal.trap('SIGTERM') { exit 0 }
end
```

**This only covers the boot window.** Once boot completes, `Runner#setup_signals` overwrites the trap with the normal graceful shutdown (drain the launcher, then `exit 0`), so runtime behaviour is unchanged — no in-flight message can be lost by this. There is nothing to drain during boot anyway: no listeners are running, so no SQS message has been received yet. Eventboss deletes messages only after successful processing, so anything mid-flight simply returns to the queue.

The trap is deliberately minimal rather than a second self-pipe: it exists purely so the exit code is 0 instead of a signal death.

## Testing

New spec forks a process, stubs `boot_system` to block, sends SIGTERM mid-boot and asserts the exit status:

- before the fix: `exitstatus` is `nil` (killed by signal, no clean exit)
- after the fix: `exitstatus` is `0`

Full suite green (109 examples, 0 failures) on Ruby 3.4.5.

## Notes

- Version bumped to 1.9.9 + CHANGELOG entry, so consumers can pick this up.
- Follow-up worth considering separately: Sidekiq chains the previous handler rather than clobbering it ([cli.rb#L55-L65](https://github.com/sidekiq/sidekiq/blob/3ab01da03a71b3c94a36f3a2f84976cbc36b6d0d/lib/sidekiq/cli.rb#L55-L65)), while `Runner#setup_signals` replaces traps unconditionally. Not needed for this bug, but it would let a host app keep its own TERM handling.
- Complementary to, not a replacement for, the chart-side change that stops resurrecting scaled-to-zero workers on deploy. That removes most of the occurrences; this makes the process correct whenever a mid-boot SIGTERM does happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)